### PR TITLE
fix for issue 65 (samplingRate/speed problems)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,6 @@ py/relocatable-python
 py/client/dist/
 py/client/*.spec
 
-
+Miniconda
 Miniconda3
 Miniconda*.sh

--- a/Source/ARA/AudioModification.cpp
+++ b/Source/ARA/AudioModification.cpp
@@ -55,7 +55,7 @@ std::string AudioModification::getSourceName() { return mAudioSourceName; }
  *
  * @param params Map of parameters for learner
  */
-void AudioModification::process(std::shared_ptr<WebWave2Wave> model) {
+void AudioModification::process(std::shared_ptr<WebWave2Wave> model, double dawSampleRate) {
   if (model == nullptr) {
     throw std::runtime_error("AudioModification::process: model is null");
     return;
@@ -71,7 +71,7 @@ void AudioModification::process(std::shared_ptr<WebWave2Wave> model) {
   else {
     auto numChannels = mAudioSourceReader->numChannels;
     auto numSamples = mAudioSourceReader->lengthInSamples;
-    auto sampleRate = mSampleRate;
+    auto sourceSampleRate = mSampleRate;
 
     DBG("AudioModification:: audio source: "
         << mAudioSourceName << " channels: " << juce::String(numChannels)
@@ -82,7 +82,7 @@ void AudioModification::process(std::shared_ptr<WebWave2Wave> model) {
     // reading into audio buffer
     mAudioSourceReader->read(mAudioBuffer.get(), 0,
                              static_cast<int>(numSamples), 0, true, true);
-    model->process(mAudioBuffer.get(), sampleRate);
+    model->process(mAudioBuffer.get(), sourceSampleRate, dawSampleRate);
 
     // connect the modified buffer to the source
 

--- a/Source/ARA/AudioModification.h
+++ b/Source/ARA/AudioModification.h
@@ -45,7 +45,7 @@ public:
   bool isThumbCreated() const;
   std::string getSourceName();
 
-  void process(std::shared_ptr<WebWave2Wave> model);
+  void process(std::shared_ptr<WebWave2Wave> model, double dawSampleRate);
 
   juce::AudioBuffer<float> *getModifiedAudioBuffer();
   bool getIsModified() const;

--- a/Source/ARA/PlaybackRenderer.cpp
+++ b/Source/ARA/PlaybackRenderer.cpp
@@ -42,7 +42,7 @@ void PlaybackRenderer::prepareToPlay(double sampleRateIn,
                                      AlwaysNonRealtime alwaysNonRealtime) {
   // DBG("PlaybackRenderer::prepareToPlay");
   numChannels = numChannelsIn;
-  DAWSampleRate = sampleRateIn;
+  dawSampleRate = sampleRateIn;
   maximumSamplesPerBlock = maximumSamplesPerBlockIn;
 
   // DBG("PlaybackRenderer::prepareToPlay - numChannels: " << numChannels << ",
@@ -71,7 +71,7 @@ void PlaybackRenderer::prepareToPlay(double sampleRateIn,
 
       } else {
         const auto readAheadSize =
-            jmax(4 * maximumSamplesPerBlock, roundToInt(2.0 * DAWSampleRate));
+            jmax(4 * maximumSamplesPerBlock, roundToInt(2.0 * dawSampleRate));
 
         readerSource = std::make_unique<juce::AudioFormatReaderSource>(
             new BufferingAudioReader(new ARAAudioSourceReader(audioSource),
@@ -82,11 +82,11 @@ void PlaybackRenderer::prepareToPlay(double sampleRateIn,
       auto resamplingSource = std::make_unique<ResamplingAudioSource>(
           readerSource.get(), false, numChannels);
 
-      resamplingSource->setResamplingRatio(audioSource->getSampleRate() / DAWSampleRate
+      resamplingSource->setResamplingRatio(audioSource->getSampleRate() / dawSampleRate
                                            );
 
-      readerSource->prepareToPlay(maximumSamplesPerBlock, DAWSampleRate);
-      resamplingSource->prepareToPlay(maximumSamplesPerBlock, DAWSampleRate);
+      readerSource->prepareToPlay(maximumSamplesPerBlock, dawSampleRate);
+      resamplingSource->prepareToPlay(maximumSamplesPerBlock, dawSampleRate);
 
       positionableSources.emplace(audioSource, std::move(readerSource));
       resamplingSources.emplace(audioSource, std::move(resamplingSource));
@@ -119,7 +119,7 @@ bool PlaybackRenderer::processBlock(
   }
 
   // all the sample-related variable names that end in assr are in the audio source sample rate
-  // all other sample-related variables are in DAW time (DAWSampleRate)
+  // all other sample-related variables are in DAW time (dawSampleRate)
   const auto numSamples = buffer.getNumSamples();
   jassert(numSamples <= maximumSamplesPerBlock);
   jassert(numChannels == buffer.getNumChannels());
@@ -157,7 +157,7 @@ bool PlaybackRenderer::processBlock(
 
       // playbackRegion sample range in DAW time
       const auto playbackSampleRange = playbackRegion->getSampleRange(
-          DAWSampleRate, ARAPlaybackRegion::IncludeHeadAndTail::no);
+          dawSampleRate, ARAPlaybackRegion::IncludeHeadAndTail::no);
       const auto playbackSampleRange_assr = playbackRegion->getSampleRange(
           sourceSampleRate, ARAPlaybackRegion::IncludeHeadAndTail::no);
 
@@ -199,8 +199,8 @@ bool PlaybackRenderer::processBlock(
           playbackRegion->getStartInAudioModificationSamples(),
           playbackRegion->getEndInAudioModificationSamples()};
       Range<int64> modificationSampleRange{
-          playbackRegion->getStartInPlaybackSamples(DAWSampleRate),
-          playbackRegion->getEndInPlaybackSamples(DAWSampleRate)};
+          playbackRegion->getStartInPlaybackSamples(dawSampleRate),
+          playbackRegion->getEndInPlaybackSamples(dawSampleRate)};
       
       const auto modificationSampleOffset_old =
           modificationSampleRange_assr.getStart() - roundToInt(playbackSampleRange.getStart() * resamplingSource->getResamplingRatio()); // playbackSampleRange is in DAW time
@@ -329,12 +329,12 @@ bool PlaybackRenderer::processBlock(
 void PlaybackRenderer::executeProcess(std::shared_ptr<WebWave2Wave> model) {
   DBG("PlaybackRenderer::executeProcess executing process");
 
-  auto callback = [model](juce::ARAPlaybackRegion *playbackRegion) -> bool {
+  auto callback = [this, model](juce::ARAPlaybackRegion *playbackRegion) -> bool {
       try {
           auto modification = playbackRegion->getAudioModification<AudioModification>();
           std::cout << "PlaybackRenderer::processing playbackRegion "
                     << modification->getSourceName() << std::endl;
-          modification->process(model);
+          modification->process(model, dawSampleRate);
       } catch (const std::runtime_error& e) {
           juce::AlertWindow::showMessageBoxAsync(
               juce::AlertWindow::WarningIcon,

--- a/Source/ARA/PlaybackRenderer.h
+++ b/Source/ARA/PlaybackRenderer.h
@@ -121,7 +121,7 @@ private:
   std::map<ARAAudioSource *, unique_ptr<AudioFormatReaderSource>>
       positionableSources;
   int numChannels = 2;
-  double DAWSampleRate;
+  double dawSampleRate;
   int maximumSamplesPerBlock = 128;
   unique_ptr<AudioBuffer<float>> tempBuffer;
 };

--- a/Source/DeepLearning/Wave2Wave.h
+++ b/Source/DeepLearning/Wave2Wave.h
@@ -91,15 +91,15 @@ protected:
     auto resamplingSource =
         std::make_unique<juce::ResamplingAudioSource>(readerSource, true, 2);
 
-    double resamplingRatio = static_cast<double>(targetSampleRate) /
-                            static_cast<double>(reader->sampleRate);
+    double resamplingRatio = static_cast<double>(reader->sampleRate) / 
+                            static_cast<double>(targetSampleRate);
     resamplingSource->setResamplingRatio(resamplingRatio);
     resamplingSource->prepareToPlay(static_cast<int>(reader->lengthInSamples), reader->sampleRate);
     DBG("Resampling ratio: " + std::to_string(resamplingRatio));
 
     // resize the buffer to account for resampling
     int resampledBufferLength = static_cast<int>(
-        static_cast<double>(reader->lengthInSamples) * resamplingRatio);
+        static_cast<double>(reader->lengthInSamples) / resamplingRatio);
     DBG("Resampled buffer length: " + std::to_string(resampledBufferLength));
 
     DBG("resizing buffer to " + std::to_string(reader->numChannels) +
@@ -118,5 +118,5 @@ public:
    * @param sampleRate The sample rate of the audio data.
    */
   virtual void process(juce::AudioBuffer<float> *bufferToProcess,
-                       int sampleRate) const = 0;
+                       int sourceSampleRate, int dawSampleRate) const = 0;
 };

--- a/Source/DeepLearning/WebModel.h
+++ b/Source/DeepLearning/WebModel.h
@@ -246,7 +246,8 @@ public:
 
 
   virtual void process(
-    juce::AudioBuffer<float> *bufferToProcess, int sampleRate
+    juce::AudioBuffer<float> *bufferToProcess, int sourceSampleRate, int dawSampleRate
+
   ) const override {
     // make sure we're loaded
     LogAndDBG("WebWave2Wave::process");
@@ -260,7 +261,7 @@ public:
         juce::File::getSpecialLocation(juce::File::tempDirectory)
             .getChildFile("input.wav");
     tempFile.deleteFile();
-    if (!save_buffer_to_file(*bufferToProcess, tempFile, sampleRate)) {
+    if (!save_buffer_to_file(*bufferToProcess, tempFile, sourceSampleRate)) {
       throw std::runtime_error("Failed to save buffer to file.");
     }
 
@@ -317,7 +318,8 @@ public:
     // TODO: the sample rate should not be the incoming sample rate, but
     // rather the output sample rate of the daw?
     LogAndDBG("Reading output file to buffer");
-    load_buffer_from_file(tempOutputFile, *bufferToProcess, sampleRate);
+    load_buffer_from_file(tempOutputFile, *bufferToProcess, dawSampleRate);
+
 
     // delete the temp input file
     tempFile.deleteFile();


### PR DESCRIPTION
Tested only on windows. If you want to test on Mac,
1. Load a 22k or 48k (or both) files.
2. Load pitchShifter, set the knob to '0' and process
3. The result should have the exact same pitch as the original