### PR TITLE
Implementing drag to reorder tracks in media clipboard (Issue 318)

### DIFF
--- a/src/MainComponent.cpp
+++ b/src/MainComponent.cpp
@@ -15,9 +15,12 @@ MainComponent::MainComponent()
     addAndMakeVisible(mainModelTab);
     addAndMakeVisible(statusAreaWidget);
     addAndMakeVisible(mediaClipboardWidget);
+    addAndMakeVisible(dragOverlay);
 
     showStatusArea = Settings::getBoolValue("view.showStatusArea", true);
     showMediaClipboard = Settings::getBoolValue("view.showMediaClipboard", false);
+    dragOverlay.setVisible(false);
+    dragOverlay.toFront(false);
 
     requiredWindowWidth = minimumWindowWidth;
     requiredWindowHeight = minimumWindowHeight;
@@ -126,6 +129,8 @@ void MainComponent::resized()
     {
         welcomeWindow->refreshHighlightForCurrentStep();
     }
+
+    dragOverlay.setBounds(getLocalBounds());
 }
 
 void MainComponent::updateWindowConstraints()

--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -152,7 +152,8 @@ private:
 
     ModelTab mainModelTab;
     StatusAreaWidget statusAreaWidget;
-    MediaClipboardWidget mediaClipboardWidget;
+    DragOverlayComponent dragOverlay;
+    MediaClipboardWidget mediaClipboardWidget { &dragOverlay };
 
     bool isTutorialActive = false;
     Rectangle<int> tutorialHighlightRect;

--- a/src/widgets/MediaClipboardWidget.h
+++ b/src/widgets/MediaClipboardWidget.h
@@ -19,7 +19,9 @@ using namespace juce;
 class MediaClipboardWidget : public Component, public ChangeListener
 {
 public:
-    MediaClipboardWidget()
+    MediaClipboardWidget(DragOverlayComponent* overlay)
+        : dragOverlay(overlay),
+          trackAreaWidget(DisplayMode::Thumbnail, 75, overlay)
     {
         selectionTextBox.onReturnKey = [this] { renameSelectionCallback(); };
         controlsComponent.addAndMakeVisible(selectionTextBox);
@@ -624,6 +626,8 @@ private:
     MultiButton::Mode sendToDAWButtonSelectedInfo;
     MultiButton::Mode sendToDAWButtonInactiveInfo1;
     MultiButton::Mode sendToDAWButtonInactiveInfo2;
+
+    DragOverlayComponent* dragOverlay = nullptr;
 
     Viewport trackArea;
     TrackAreaWidget trackAreaWidget { DisplayMode::Thumbnail, 75 };

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -27,6 +27,7 @@ public:
     TrackAreaWidget(DisplayMode mode = DisplayMode::Input, int trackHeight = 0)
         : displayMode(mode), fixedTrackHeight(trackHeight)
     {
+        addMouseListener(this, true);
     }
 
     ~TrackAreaWidget() { resetState(); }
@@ -34,6 +35,24 @@ public:
     void paint(Graphics& g) override
     {
         g.fillAll(getUIColourIfAvailable(LookAndFeel_V4::ColourScheme::UIColour::windowBackground));
+        
+        // Draws drop line for track reordering
+        if (isDraggingTrack && dragInsertIndex >= 0)
+        {
+            int trackSlotHeight = fixedTrackHeight + static_cast<int>(2 * marginSize);
+            int lineY = dragInsertIndex * trackSlotHeight;
+
+            g.setColour(Colours::white);
+            g.fillRect(0, lineY - 1, getWidth(), 3);
+        }
+
+        // Makes the dragged track look visually distinct
+        if (isDraggingTrack && draggedTrack != nullptr)
+        {
+            Rectangle<int> draggedBounds = draggedTrack->getBounds();
+            g.setColour(Colours::black.withAlpha(0.3f));
+            g.fillRect(draggedBounds);
+        }
     }
 
     void resized() override
@@ -328,6 +347,25 @@ public:
         resized();
     }
 
+    void reorderTrack(MediaDisplayComponent* draggedDisplay, int newIndex)
+    {
+        auto it =
+            std::find_if(mediaDisplays.begin(), 
+                         mediaDisplays.end(),
+                         [draggedDisplay](const auto& ptr) { return ptr.get() == draggedDisplay; });
+        
+        if (it == mediaDisplays.end()) return;
+
+        auto draggedPtr = std::move(*it);
+        mediaDisplays.erase(it);
+
+        newIndex = jlimit(0, (int)mediaDisplays.size(), newIndex);
+
+        mediaDisplays.insert(mediaDisplays.begin() + newIndex, std::move(draggedPtr));
+
+        resized();
+    }
+
     void filesDropped(const StringArray& files, int /*x*/, int /*y*/) override
     {
         for (String f : files)
@@ -357,12 +395,97 @@ private:
         }
     }
 
+    int getInsertIndexAtY(int y)
+    {
+        int trackSlotHeight = fixedTrackHeight + static_cast<int>(2 * marginSize);
+        int index = y / trackSlotHeight;
+        return jlimit(0, getNumTracks(), index);
+    }
+
+    void mouseDown(const MouseEvent& e) override
+    {
+        if (!isThumbnailWidget()) return;
+
+        Component* clicked = e.eventComponent;
+        
+        MediaDisplayComponent* clickedDisplay = nullptr;
+        Component* c = clicked;
+        while (c != nullptr && c != this)
+        {
+            if (auto* md = dynamic_cast<MediaDisplayComponent*>(c))
+            {
+                clickedDisplay = md;
+                break;
+            }
+            c = c->getParentComponent();
+        }
+
+        if (clickedDisplay)
+        {
+            draggedTrack = clickedDisplay;
+            isDraggingTrack = false;
+        }
+    }
+
+    void mouseDrag(const MouseEvent& e) override
+    {
+        if (!isThumbnailWidget() || draggedTrack == nullptr) return;
+
+        Point<int> posInThis = e.getEventRelativeTo(this).getPosition();
+
+        if (!isDraggingTrack && e.getDistanceFromDragStart() > 5)
+        {
+            isDraggingTrack = true;
+        }
+
+        if (isDraggingTrack)
+        {
+            dragInsertIndex = getInsertIndexAtY(posInThis.y);
+            // Draws the drop indicator line
+            repaint();
+        }
+    }
+
+    void mouseUp(const MouseEvent& e) override
+    {
+        if (!isThumbnailWidget()) return;
+
+        if (isDraggingTrack && draggedTrack != nullptr)
+        {
+            int currentIndex = -1;
+            for (int i = 0; i < (int)mediaDisplays.size(); i++)
+            {
+                if (mediaDisplays[i].get() == draggedTrack)
+                {
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            if (dragInsertIndex != currentIndex && dragInsertIndex != currentIndex + 1)
+            {
+                reorderTrack(draggedTrack, dragInsertIndex);
+            }
+        }
+
+        // Reset the drag state
+        draggedTrack = nullptr;
+        dragInsertIndex = -1;
+        isDraggingTrack = false;
+        repaint();
+    }
+
     const DisplayMode displayMode;
     const int fixedTrackHeight = 0;
 
     const float marginSize = 4;
     int fixedTotalWidth = 0;
     int minTotalHeight = 0;
+
+    // For reordering tracks via dragging
+    MediaDisplayComponent* draggedTrack = nullptr;
+    int dragInsertIndex = -1;
+    bool isDraggingTrack = false;
 
     std::vector<std::unique_ptr<MediaDisplayComponent>> mediaDisplays;
 };

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -18,14 +18,85 @@
 
 using namespace juce;
 
+class DragOverlayComponent : public Component
+{
+public:
+    DragOverlayComponent()
+    {
+        setInterceptsMouseClicks(false, false);
+    }
+
+    void startDrag(Image snapshot, Point<int> offset)
+    {
+        if (isActive) return;
+        dragImage = snapshot;
+        dragOffset = offset;
+        isActive = true;
+        setVisible(true);
+        repaint();
+    }
+
+    // Called every mouseDrag event with the current mouse position
+    void updatePosition(Point<int> newPos)
+    {
+        if (newPos == currentPos) return;
+
+        // Clear old position
+        repaint(currentPos.x - dragOffset.x,
+                currentPos.y - dragOffset.y,
+                dragImage.getWidth(),
+                dragImage.getHeight());
+
+        currentPos = newPos;
+
+        // Repaint only new position
+        repaint(currentPos.x - dragOffset.x,
+                currentPos.y - dragOffset.y,
+                dragImage.getWidth(),
+                dragImage.getHeight());
+    }
+
+    void stopDrag()
+    {
+        isActive = false;
+        dragImage = Image(); // Releases the image data
+        setVisible(false);
+        repaint();
+    }
+
+    void paint(Graphics& g) override
+    {
+        if (!isActive || dragImage.isNull())
+            return;
+
+        g.drawImage(dragImage,
+                    currentPos.x - dragOffset.x,
+                    currentPos.y - dragOffset.y,
+                    dragImage.getWidth(),
+                    dragImage.getHeight(),
+                    0,
+                    0,
+                    dragImage.getWidth(),
+                    dragImage.getHeight());
+    }
+
+private:
+    Image dragImage;
+    Point<int> currentPos;
+    Point<int> dragOffset;
+    bool isActive = false;
+};
+
 class TrackAreaWidget : public Component,
                         public ChangeListener,
                         public ChangeBroadcaster,
                         public FileDragAndDropTarget
 {
 public:
-    TrackAreaWidget(DisplayMode mode = DisplayMode::Input, int trackHeight = 0)
-        : displayMode(mode), fixedTrackHeight(trackHeight)
+    TrackAreaWidget(DisplayMode mode = DisplayMode::Input,
+                    int trackHeight = 0,
+                    DragOverlayComponent* overlay = nullptr)
+        : displayMode(mode), fixedTrackHeight(trackHeight), dragOverlay(overlay)
     {
         addMouseListener(this, true);
     }
@@ -35,24 +106,6 @@ public:
     void paint(Graphics& g) override
     {
         g.fillAll(getUIColourIfAvailable(LookAndFeel_V4::ColourScheme::UIColour::windowBackground));
-        
-        // Draws drop line for track reordering
-        if (isDraggingTrack && dragInsertIndex >= 0)
-        {
-            int trackSlotHeight = fixedTrackHeight + static_cast<int>(2 * marginSize);
-            int lineY = dragInsertIndex * trackSlotHeight;
-
-            g.setColour(Colours::white);
-            g.fillRect(0, lineY - 1, getWidth(), 3);
-        }
-
-        // Makes the dragged track look visually distinct
-        if (isDraggingTrack && draggedTrack != nullptr)
-        {
-            Rectangle<int> draggedBounds = draggedTrack->getBounds();
-            g.setColour(Colours::black.withAlpha(0.3f));
-            g.fillRect(draggedBounds);
-        }
     }
 
     void resized() override
@@ -66,8 +119,32 @@ public:
 
         if (getNumTracks() > 0)
         {
+            int draggedIndex = isDraggingTrack ? getDraggedTrackIndex() : -1;
+
+            int visualGapIndex = dragInsertIndex;
+            if (isDraggingTrack && draggedIndex >= 0 && dragInsertIndex > draggedIndex)
+                visualGapIndex = dragInsertIndex - 1;
+
+            int layoutIndex = 0;
+
             for (auto& m : mediaDisplays)
             {
+                // Don't draw dragged track
+                if (m.get() == draggedTrack && isDraggingTrack)
+                    continue;
+
+                if (isDraggingTrack && dragInsertIndex >= 0 && layoutIndex == visualGapIndex)
+                {
+                    FlexItem gap;
+
+                    if (fixedTrackHeight)
+                        gap = FlexItem().withHeight(fixedTrackHeight).withMargin(marginSize);
+                    else  
+                        gap = FlexItem().withFlex(1).withMinHeight(50).withMargin(marginSize);
+
+                    mainBox.items.add(gap);
+                }
+
                 FlexItem i = FlexItem(*m);
 
                 if (fixedTrackHeight)
@@ -80,6 +157,21 @@ public:
                 }
 
                 mainBox.items.add(i.withMargin(marginSize));
+
+                layoutIndex++;
+            }
+
+            // If the drag gap is at the end of the list
+            if (isDraggingTrack && dragInsertIndex >= 0 && layoutIndex == visualGapIndex)
+            {
+                FlexItem gap;
+
+                if (fixedTrackHeight)
+                    gap = FlexItem().withHeight(fixedTrackHeight).withMargin(marginSize);
+                else
+                    gap = FlexItem().withFlex(1).withMinHeight(50).withMargin(marginSize);
+
+                mainBox.items.add(gap);
             }
 
             if (fixedTrackHeight)
@@ -362,7 +454,6 @@ public:
         auto draggedPtr = std::move(*it);
         mediaDisplays.erase(it);
 
-
         // Decrement index if moving downward to account for shifting indicies
         if (newIndex > oldIndex)
             newIndex--;
@@ -406,13 +497,41 @@ private:
     int getInsertIndexAtY(int y)
     {
         int trackSlotHeight = fixedTrackHeight + static_cast<int>(2 * marginSize);
+        
+        if (isDraggingTrack && draggedTrack != nullptr)
+        {
+            int draggedIndex = getDraggedTrackIndex();
+
+            int draggedSlotTop = draggedIndex * trackSlotHeight;
+
+            if (draggedIndex >= 0 && y > draggedSlotTop)
+                y += trackSlotHeight;
+        }
+
         int index = y / trackSlotHeight;
         return jlimit(0, getNumTracks(), index);
+    }
+
+    int getDraggedTrackIndex() const
+    {
+        if (draggedTrack == nullptr) return -1;
+
+        for (int i = 0; i < (int)mediaDisplays.size(); i++)
+        {
+            if (mediaDisplays[i].get() == draggedTrack)
+                return i;
+        }
+
+        return -1;
     }
 
     void mouseDown(const MouseEvent& e) override
     {
         if (!isThumbnailWidget()) return;
+
+        // Reset drag state at the start of every click
+        draggedTrack = nullptr;
+        isDraggingTrack = false;
 
         Component* clicked = e.eventComponent;
         
@@ -431,7 +550,10 @@ private:
         if (clickedDisplay)
         {
             draggedTrack = clickedDisplay;
-            isDraggingTrack = false;
+
+            Point<int> mouseInThis = e.getEventRelativeTo(this).getPosition();
+            Point<int> trackTopLeft = draggedTrack->getBounds().getTopLeft();
+            dragClickOffset = mouseInThis - trackTopLeft;
         }
     }
 
@@ -444,23 +566,35 @@ private:
         if (!isDraggingTrack && e.getDistanceFromDragStart() > 5)
         {
             isDraggingTrack = true;
+
+            // Takes a snapshot of the track at the moment dragging starts
+            if (dragOverlay != nullptr)
+            {
+                Image snapshot = draggedTrack->createComponentSnapshot(draggedTrack->getLocalBounds());
+                dragOverlay->startDrag(snapshot, dragClickOffset);
+                draggedTrack->setVisible(false);
+            }
         }
 
         if (isDraggingTrack)
         {
-            // Only update the drop index while inside the widget
+            int newInsertIndex = -1;
+
             if (getLocalBounds().contains(posInThis))
+                newInsertIndex = getInsertIndexAtY(posInThis.y);
+
+            if (newInsertIndex != dragInsertIndex)
             {
-                dragInsertIndex = getInsertIndexAtY(posInThis.y);
-            }
-            else
-            {
-                // Hides the indicator line when outside the widget
-                dragInsertIndex = -1;
+                dragInsertIndex = newInsertIndex;
+                resized();
             }
 
-            // Updates the drop indicator line
-            repaint();
+            // Converts the position to the overlay's coordinate space
+            if (dragOverlay != nullptr)
+            {
+                Point<int> posInOverlay = dragOverlay->getLocalPoint(this, posInThis);
+                dragOverlay->updatePosition(posInOverlay);
+            }
         }
     }
 
@@ -468,33 +602,32 @@ private:
     {
         if (!isThumbnailWidget()) return;
 
-        // Tracks the release psoition of the mouse
+        // Tracks the release position of the mouse
         Point<int> releasePos = e.getEventRelativeTo(this).getPosition();
 
         // Only reorders if the mouse was released inside the widget
         if (isDraggingTrack && draggedTrack != nullptr && getLocalBounds().contains(releasePos))
         {
-            int currentIndex = -1;
-            for (int i = 0; i < (int)mediaDisplays.size(); i++)
-            {
-                if (mediaDisplays[i].get() == draggedTrack)
-                {
-                    currentIndex = i;
-                    break;
-                }
-            }
+            int currentIndex = getDraggedTrackIndex();
 
-            if (dragInsertIndex != currentIndex && dragInsertIndex != currentIndex + 1)
+            if (dragInsertIndex != currentIndex)
             {
                 reorderTrack(draggedTrack, dragInsertIndex);
             }
         }
 
+        // Restore the track's appearance and stop the overlay
+        if (draggedTrack != nullptr)
+            draggedTrack->setVisible(true);
+        if (dragOverlay != nullptr)
+            dragOverlay->stopDrag();
+
         // Reset the drag state
         draggedTrack = nullptr;
         dragInsertIndex = -1;
         isDraggingTrack = false;
-        repaint();
+
+        resized();
     }
 
     const DisplayMode displayMode;
@@ -506,8 +639,10 @@ private:
 
     // For reordering tracks via dragging
     MediaDisplayComponent* draggedTrack = nullptr;
+    DragOverlayComponent* dragOverlay = nullptr;
     int dragInsertIndex = -1;
     bool isDraggingTrack = false;
+    Point<int> dragClickOffset { 0, 0 };
 
     std::vector<std::unique_ptr<MediaDisplayComponent>> mediaDisplays;
 };

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -356,8 +356,16 @@ public:
         
         if (it == mediaDisplays.end()) return;
 
+        // Track the old index for downward reordering
+        int oldIndex = std::distance(mediaDisplays.begin(), it);
+
         auto draggedPtr = std::move(*it);
         mediaDisplays.erase(it);
+
+
+        // Decrement index if moving downward to account for shifting indicies
+        if (newIndex > oldIndex)
+            newIndex--;
 
         newIndex = jlimit(0, (int)mediaDisplays.size(), newIndex);
 
@@ -440,8 +448,18 @@ private:
 
         if (isDraggingTrack)
         {
-            dragInsertIndex = getInsertIndexAtY(posInThis.y);
-            // Draws the drop indicator line
+            // Only update the drop index while inside the widget
+            if (getLocalBounds().contains(posInThis))
+            {
+                dragInsertIndex = getInsertIndexAtY(posInThis.y);
+            }
+            else
+            {
+                // Hides the indicator line when outside the widget
+                dragInsertIndex = -1;
+            }
+
+            // Updates the drop indicator line
             repaint();
         }
     }
@@ -450,7 +468,11 @@ private:
     {
         if (!isThumbnailWidget()) return;
 
-        if (isDraggingTrack && draggedTrack != nullptr)
+        // Tracks the release psoition of the mouse
+        Point<int> releasePos = e.getEventRelativeTo(this).getPosition();
+
+        // Only reorders if the mouse was released inside the widget
+        if (isDraggingTrack && draggedTrack != nullptr && getLocalBounds().contains(releasePos))
         {
             int currentIndex = -1;
             for (int i = 0; i < (int)mediaDisplays.size(); i++)

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -87,6 +87,29 @@ private:
     bool isActive = false;
 };
 
+class GhostTrackComponent : public Component
+{
+public:
+    void setImage(const Image& img)
+    {
+        ghostImage = img;
+        repaint();
+    }
+
+    void paint(Graphics& g) override
+    {
+        if (ghostImage.isNull()) return;
+
+        g.setOpacity(0.4f);
+        g.drawImage(ghostImage,
+                    getLocalBounds().toFloat(),
+                    RectanglePlacement::stretchToFit);
+    }
+
+private:
+    Image ghostImage;
+};
+
 class TrackAreaWidget : public Component,
                         public ChangeListener,
                         public ChangeBroadcaster,
@@ -99,6 +122,7 @@ public:
         : displayMode(mode), fixedTrackHeight(trackHeight), dragOverlay(overlay)
     {
         addMouseListener(this, true);
+        addChildComponent(ghostTrack);
     }
 
     ~TrackAreaWidget() { resetState(); }
@@ -136,12 +160,22 @@ public:
                 if (isDraggingTrack && dragInsertIndex >= 0 && layoutIndex == visualGapIndex)
                 {
                     FlexItem gap;
-
-                    if (fixedTrackHeight)
-                        gap = FlexItem().withHeight(fixedTrackHeight).withMargin(marginSize);
-                    else  
-                        gap = FlexItem().withFlex(1).withMinHeight(50).withMargin(marginSize);
-
+                    if (isDraggingOutside)
+                    {
+                        ghostTrack.setVisible(true);
+                        if (fixedTrackHeight)
+                            gap = FlexItem(ghostTrack).withHeight(fixedTrackHeight).withMargin(marginSize);
+                        else
+                            gap = FlexItem(ghostTrack).withFlex(1).withMinHeight(50).withMargin(marginSize);
+                    }
+                    else
+                    {
+                        ghostTrack.setVisible(false);
+                        if (fixedTrackHeight)
+                            gap = FlexItem().withHeight(fixedTrackHeight).withMargin(marginSize);
+                        else
+                            gap = FlexItem().withFlex(1).withMinHeight(50).withMargin(marginSize);
+                    }
                     mainBox.items.add(gap);
                 }
 
@@ -165,12 +199,22 @@ public:
             if (isDraggingTrack && dragInsertIndex >= 0 && layoutIndex == visualGapIndex)
             {
                 FlexItem gap;
-
-                if (fixedTrackHeight)
-                    gap = FlexItem().withHeight(fixedTrackHeight).withMargin(marginSize);
+                if (isDraggingOutside)
+                {
+                    ghostTrack.setVisible(true);
+                    if (fixedTrackHeight)
+                        gap = FlexItem(ghostTrack).withHeight(fixedTrackHeight).withMargin(marginSize);
+                    else
+                        gap = FlexItem(ghostTrack).withFlex(1).withMinHeight(50).withMargin(marginSize);
+                }
                 else
-                    gap = FlexItem().withFlex(1).withMinHeight(50).withMargin(marginSize);
-
+                {
+                    ghostTrack.setVisible(false);
+                    if (fixedTrackHeight)
+                        gap = FlexItem().withHeight(fixedTrackHeight).withMargin(marginSize);
+                    else
+                        gap = FlexItem().withFlex(1).withMinHeight(50).withMargin(marginSize);
+                }
                 mainBox.items.add(gap);
             }
 
@@ -572,6 +616,7 @@ private:
             if (dragOverlay != nullptr)
             {
                 Image snapshot = draggedTrack->createComponentSnapshot(draggedTrack->getLocalBounds());
+                ghostTrack.setImage(snapshot);
                 dragOverlay->startDrag(snapshot, dragClickOffset);
                 draggedTrack->setVisible(false);
             }
@@ -580,17 +625,20 @@ private:
         if (isDraggingTrack)
         {
             int newInsertIndex = -1;
+            bool wasOutside = isDraggingOutside;
 
             if (getLocalBounds().contains(posInThis))
             {
                 newInsertIndex = getInsertIndexAtY(posInThis.y);
+                isDraggingOutside = false;
             }
             else
             {
                 newInsertIndex = dragOriginIndex;
+                isDraggingOutside = true;
             }
 
-            if (newInsertIndex != dragInsertIndex)
+            if (newInsertIndex != dragInsertIndex || isDraggingOutside != wasOutside)
             {
                 dragInsertIndex = newInsertIndex;
                 resized();
@@ -634,6 +682,8 @@ private:
         dragInsertIndex = -1;
         dragOriginIndex = -1;
         isDraggingTrack = false;
+        isDraggingOutside = false;
+        ghostTrack.setVisible(false);
 
         resized();
     }
@@ -648,9 +698,11 @@ private:
     // For reordering tracks via dragging
     MediaDisplayComponent* draggedTrack = nullptr;
     DragOverlayComponent* dragOverlay = nullptr;
+    GhostTrackComponent ghostTrack;
     int dragInsertIndex = -1;
     int dragOriginIndex = -1;
     bool isDraggingTrack = false;
+    bool isDraggingOutside = false;
     Point<int> dragClickOffset { 0, 0 };
 
     std::vector<std::unique_ptr<MediaDisplayComponent>> mediaDisplays;

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -550,6 +550,7 @@ private:
         if (clickedDisplay)
         {
             draggedTrack = clickedDisplay;
+            dragOriginIndex = getDraggedTrackIndex();
 
             Point<int> mouseInThis = e.getEventRelativeTo(this).getPosition();
             Point<int> trackTopLeft = draggedTrack->getBounds().getTopLeft();
@@ -581,7 +582,13 @@ private:
             int newInsertIndex = -1;
 
             if (getLocalBounds().contains(posInThis))
+            {
                 newInsertIndex = getInsertIndexAtY(posInThis.y);
+            }
+            else
+            {
+                newInsertIndex = dragOriginIndex;
+            }
 
             if (newInsertIndex != dragInsertIndex)
             {
@@ -625,6 +632,7 @@ private:
         // Reset the drag state
         draggedTrack = nullptr;
         dragInsertIndex = -1;
+        dragOriginIndex = -1;
         isDraggingTrack = false;
 
         resized();
@@ -641,6 +649,7 @@ private:
     MediaDisplayComponent* draggedTrack = nullptr;
     DragOverlayComponent* dragOverlay = nullptr;
     int dragInsertIndex = -1;
+    int dragOriginIndex = -1;
     bool isDraggingTrack = false;
     Point<int> dragClickOffset { 0, 0 };
 


### PR DESCRIPTION
## Issue 318

Implemented drag-and-drop for reordering tracks in the media clipboard. Created some mouse event overrides to detect dragging behavior with a drag threshold of 5 pixels, and made some changes to the painting of the `TrackAreaWidget` to display and update a drop line. The appearance (color, thickness) of the drop line can be discussed before merging.

**Files modified:**
TrackAreaWidget.h