### PR TITLE
Bugfix/374 disable open during processing

### DIFF
--- a/src/ModelTab.h
+++ b/src/ModelTab.h
@@ -493,8 +493,12 @@ private:
         modelSelectionWidget.setDisabled();
         processCancelButton.setMode(cancelButtonInfo.displayLabel);
 
-        // Disable all input track Open File buttons during processing
+        // Disable all track Open File buttons (input and output) during processing
         for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+        {
+            mediaDisplay->setChooseFileButtonEnabled(false);
+        }
+        for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
         {
             mediaDisplay->setChooseFileButtonEnabled(false);
         }
@@ -534,8 +538,12 @@ private:
                                 .setFinishedState(); // TODO - should this be last selected?
                             processCancelButton.setMode(processButtonInfo.displayLabel);
 
-                            // Re-enable all input track Open File buttons after processing
+                            // Re-enable all track Open File buttons (input and output) after processing
                             for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+                            {
+                                mediaDisplay->setChooseFileButtonEnabled(true);
+                            }
+                            for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
                             {
                                 mediaDisplay->setChooseFileButtonEnabled(true);
                             }
@@ -585,8 +593,12 @@ private:
         processCancelButton.setMode(processButtonInfo.displayLabel);
         processCancelButton.setEnabled(true);
 
-        // Re-enable all input track Open File buttons after cancel
+        // Re-enable all track Open File buttons (input and output) after cancel
         for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+        {
+            mediaDisplay->setChooseFileButtonEnabled(true);
+        }
+        for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
         {
             mediaDisplay->setChooseFileButtonEnabled(true);
         }

--- a/src/ModelTab.h
+++ b/src/ModelTab.h
@@ -493,6 +493,12 @@ private:
         modelSelectionWidget.setDisabled();
         processCancelButton.setMode(cancelButtonInfo.displayLabel);
 
+        // Disable all input track Open File buttons during processing
+        for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+        {
+            mediaDisplay->setChooseFileButtonEnabled(false);
+        }
+
         uint64_t processID = currentProcessID;
 
         processingThreadPool.addJob(
@@ -527,6 +533,12 @@ private:
                             modelSelectionWidget
                                 .setFinishedState(); // TODO - should this be last selected?
                             processCancelButton.setMode(processButtonInfo.displayLabel);
+
+                            // Re-enable all input track Open File buttons after processing
+                            for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+                            {
+                                mediaDisplay->setChooseFileButtonEnabled(true);
+                            }
                         };
 
                         if (result.wasOk())
@@ -572,6 +584,12 @@ private:
 
         processCancelButton.setMode(processButtonInfo.displayLabel);
         processCancelButton.setEnabled(true);
+
+        // Re-enable all input track Open File buttons after cancel
+        for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+        {
+            mediaDisplay->setChooseFileButtonEnabled(true);
+        }
     }
 
     static constexpr float marginSize = 2;

--- a/src/gui/MultiButton.cpp
+++ b/src/gui/MultiButton.cpp
@@ -16,9 +16,13 @@ void MultiButton::paintButton(Graphics& g,
 {
     LookAndFeel& lf = getLookAndFeel();
 
+    Colour bgColour = findColour(getToggleState() ? buttonOnColourId : buttonColourId);
+    if (! isEnabled())
+        bgColour = bgColour.withMultipliedAlpha(0.5f);
+
     lf.drawButtonBackground(g,
                             *this,
-                            findColour(getToggleState() ? buttonOnColourId : buttonColourId),
+                            bgColour,
                             shouldDrawButtonAsHighlighted,
                             shouldDrawButtonAsDown);
 
@@ -59,6 +63,10 @@ void MultiButton::paintButton(Graphics& g,
 
         Colour modeColor = modes[currentModeKey].iconColor;
 
+        const float iconAlpha = isEnabled() ? 1.0f : 0.5f;
+        g.saveState();
+        g.setOpacity(iconAlpha);
+
         if (modes[currentModeKey].iconType == IconType::FontAwesome)
         {
             currentIconKey = modes[currentModeKey].awesomeIcon;
@@ -75,6 +83,8 @@ void MultiButton::paintButton(Graphics& g,
 
             fontaudioHelper->drawCenterdAt(g, icon, getLocalBounds(), 1.0f);
         }
+
+        g.restoreState();
     }
 }
 

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -121,6 +121,8 @@ public:
     void deselectTrack();
     bool isCurrentlySelected() { return isSelected; }
 
+    void setChooseFileButtonEnabled(bool enabled) { chooseFileButton.setEnabled(enabled); }
+
     void start();
     void stop();
 


### PR DESCRIPTION
Fix #374: Disable Open File button/operations while tracks are processing

- ModelTab.h: Added logic to disable the Open File button during track processing.
- MediaDisplayComponent.h: Updated component handling to prevent user actions while processing.