### PR TITLE
Bugfix/374 disable open file during processing

### DIFF
--- a/src/ModelTab.h
+++ b/src/ModelTab.h
@@ -104,10 +104,7 @@ public:
         return bounds.expanded(2, 2);
     }
 
-    bool isModelLoaded()
-    {
-        return model->isLoaded();
-    }
+    bool isModelLoaded() { return model->isLoaded(); }
 
     void resized() override
     {
@@ -494,10 +491,7 @@ private:
         processCancelButton.setMode(cancelButtonInfo.displayLabel);
 
         // Switch choose-file button to inactive mode on all tracks during processing
-        for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
-            mediaDisplay->setChooseFileButtonEnabled(false);
-        for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
-            mediaDisplay->setChooseFileButtonEnabled(false);
+        inputTrackAreaWidget.setLoadTrackEnabled(false);
 
         uint64_t processID = currentProcessID;
 
@@ -535,10 +529,7 @@ private:
                             processCancelButton.setMode(processButtonInfo.displayLabel);
 
                             // Switch choose-file button back to active on all tracks
-                            for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
-                                mediaDisplay->setChooseFileButtonEnabled(true);
-                            for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
-                                mediaDisplay->setChooseFileButtonEnabled(true);
+                            inputTrackAreaWidget.setLoadTrackEnabled(true);
                         };
 
                         if (result.wasOk())
@@ -586,10 +577,7 @@ private:
         processCancelButton.setEnabled(true);
 
         // Switch choose-file button back to active on all tracks
-        for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
-            mediaDisplay->setChooseFileButtonEnabled(true);
-        for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
-            mediaDisplay->setChooseFileButtonEnabled(true);
+        inputTrackAreaWidget.setLoadTrackEnabled(true);
     }
 
     static constexpr float marginSize = 2;

--- a/src/ModelTab.h
+++ b/src/ModelTab.h
@@ -493,6 +493,12 @@ private:
         modelSelectionWidget.setDisabled();
         processCancelButton.setMode(cancelButtonInfo.displayLabel);
 
+        // Switch choose-file button to inactive mode on all tracks during processing
+        for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+            mediaDisplay->setChooseFileButtonEnabled(false);
+        for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
+            mediaDisplay->setChooseFileButtonEnabled(false);
+
         uint64_t processID = currentProcessID;
 
         processingThreadPool.addJob(
@@ -527,6 +533,12 @@ private:
                             modelSelectionWidget
                                 .setFinishedState(); // TODO - should this be last selected?
                             processCancelButton.setMode(processButtonInfo.displayLabel);
+
+                            // Switch choose-file button back to active on all tracks
+                            for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+                                mediaDisplay->setChooseFileButtonEnabled(true);
+                            for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
+                                mediaDisplay->setChooseFileButtonEnabled(true);
                         };
 
                         if (result.wasOk())
@@ -572,6 +584,12 @@ private:
 
         processCancelButton.setMode(processButtonInfo.displayLabel);
         processCancelButton.setEnabled(true);
+
+        // Switch choose-file button back to active on all tracks
+        for (auto& mediaDisplay : inputTrackAreaWidget.getMediaDisplays())
+            mediaDisplay->setChooseFileButtonEnabled(true);
+        for (auto& mediaDisplay : outputTrackAreaWidget.getMediaDisplays())
+            mediaDisplay->setChooseFileButtonEnabled(true);
     }
 
     static constexpr float marginSize = 2;

--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -80,7 +80,12 @@ void MediaDisplayComponent::initializeButtons()
                                                MultiButton::DrawingMode::IconOnly,
                                                Colours::lightblue,
                                                fontawesome::Folder };
+    chooseFileButtonInactiveInfo =
+        MultiButton::Mode { "ChooseFile-Inactive", "Cannot choose file while processing.",
+                            [this] {}, MultiButton::DrawingMode::IconOnly,
+                            Colours::lightgrey, fontawesome::Folder };
     chooseFileButton.addMode(chooseFileButtonInfo);
+    chooseFileButton.addMode(chooseFileButtonInactiveInfo);
     headerComponent.addAndMakeVisible(chooseFileButton);
 
     // Mode when an unsaved file is loaded
@@ -1012,6 +1017,12 @@ void MediaDisplayComponent::updateCursorPosition()
 
     currentPositionCursor.setRectangle(
         Rectangle<float>(cursorPositionX, cursorPositionY, cursorWidth, mediaBounds.getHeight()));
+}
+
+void MediaDisplayComponent::setChooseFileButtonEnabled(bool enabled)
+{
+    chooseFileButton.setMode(enabled ? chooseFileButtonInfo.displayLabel
+                                     : chooseFileButtonInactiveInfo.displayLabel);
 }
 
 Rectangle<int> MediaDisplayComponent::getChooseFileButtonBounds()

--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -74,17 +74,19 @@ void MediaDisplayComponent::initializeButtons()
     playStopButton.addMode(stopButtonInfo);
     headerComponent.addAndMakeVisible(playStopButton);
 
-    chooseFileButtonInfo = MultiButton::Mode { "ChooseFile",
-                                               "Click to choose a media file.",
-                                               [this] { chooseFileCallback(); },
-                                               MultiButton::DrawingMode::IconOnly,
-                                               Colours::lightblue,
-                                               fontawesome::Folder };
-    chooseFileButtonInactiveInfo =
-        MultiButton::Mode { "ChooseFile-Inactive", "Cannot choose file while processing.",
-                            [this] {}, MultiButton::DrawingMode::IconOnly,
-                            Colours::lightgrey, fontawesome::Folder };
-    chooseFileButton.addMode(chooseFileButtonInfo);
+    chooseFileButtonActiveInfo = MultiButton::Mode { "ChooseFile",
+                                                     "Click to choose a media file.",
+                                                     [this] { chooseFileCallback(); },
+                                                     MultiButton::DrawingMode::IconOnly,
+                                                     Colours::lightblue,
+                                                     fontawesome::Folder };
+    chooseFileButtonInactiveInfo = MultiButton::Mode { "ChooseFile-Inactive",
+                                                       "Cannot choose file while processing.",
+                                                       [this] {},
+                                                       MultiButton::DrawingMode::IconOnly,
+                                                       Colours::lightgrey,
+                                                       fontawesome::Folder };
+    chooseFileButton.addMode(chooseFileButtonActiveInfo);
     chooseFileButton.addMode(chooseFileButtonInactiveInfo);
     headerComponent.addAndMakeVisible(chooseFileButton);
 
@@ -398,6 +400,12 @@ void MediaDisplayComponent::setTrackName(String name)
     trackNameLabel.setText(trackName, dontSendNotification);
 }
 
+void MediaDisplayComponent::setChooseFileButtonEnabled(bool enabled)
+{
+    chooseFileButton.setMode(enabled ? chooseFileButtonActiveInfo.displayLabel
+                                     : chooseFileButtonInactiveInfo.displayLabel);
+}
+
 void MediaDisplayComponent::resetDisplay()
 {
     clearLabels();
@@ -431,7 +439,7 @@ void MediaDisplayComponent::resetScrollBar()
 void MediaDisplayComponent::resetButtonState()
 {
     playStopButton.setMode(playButtonInactiveInfo.displayLabel);
-    chooseFileButton.setMode(chooseFileButtonInfo.displayLabel);
+    chooseFileButton.setMode(chooseFileButtonActiveInfo.displayLabel);
     saveFileButton.setMode(saveFileButtonInactiveInfo.displayLabel);
 }
 
@@ -1017,12 +1025,6 @@ void MediaDisplayComponent::updateCursorPosition()
 
     currentPositionCursor.setRectangle(
         Rectangle<float>(cursorPositionX, cursorPositionY, cursorWidth, mediaBounds.getHeight()));
-}
-
-void MediaDisplayComponent::setChooseFileButtonEnabled(bool enabled)
-{
-    chooseFileButton.setMode(enabled ? chooseFileButtonInfo.displayLabel
-                                     : chooseFileButtonInactiveInfo.displayLabel);
 }
 
 Rectangle<int> MediaDisplayComponent::getChooseFileButtonBounds()

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -126,6 +126,8 @@ public:
 
     virtual bool isPlaying() { return transportSource.isPlaying(); }
 
+    void setChooseFileButtonEnabled(bool enabled);
+
     Rectangle<int> getChooseFileButtonBounds();
     Rectangle<int> getPlayButtonBounds();
 
@@ -244,6 +246,7 @@ private:
     MultiButton::Mode stopButtonInfo;
     MultiButton chooseFileButton;
     MultiButton::Mode chooseFileButtonInfo;
+    MultiButton::Mode chooseFileButtonInactiveInfo;
     MultiButton saveFileButton;
     MultiButton::Mode saveFileButtonActiveInfo;
     MultiButton::Mode saveFileButtonInactiveInfo;

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -85,6 +85,8 @@ public:
 
     void setMediaInstructions(String instructions) { mediaInstructions = instructions; }
 
+    void setChooseFileButtonEnabled(bool enabled);
+
     void resetDisplay(); // Reset all state and media
     void initializeDisplay(const URL& filePath); // Initialize new display
     void updateDisplay(const URL& filePath); // Add new file to existing display
@@ -125,8 +127,6 @@ public:
     void stop();
 
     virtual bool isPlaying() { return transportSource.isPlaying(); }
-
-    void setChooseFileButtonEnabled(bool enabled);
 
     Rectangle<int> getChooseFileButtonBounds();
     Rectangle<int> getPlayButtonBounds();
@@ -245,7 +245,7 @@ private:
     MultiButton::Mode playButtonInactiveInfo;
     MultiButton::Mode stopButtonInfo;
     MultiButton chooseFileButton;
-    MultiButton::Mode chooseFileButtonInfo;
+    MultiButton::Mode chooseFileButtonActiveInfo;
     MultiButton::Mode chooseFileButtonInactiveInfo;
     MultiButton saveFileButton;
     MultiButton::Mode saveFileButtonActiveInfo;

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -165,6 +165,14 @@ public:
     bool isHybridWidget() { return displayMode == DisplayMode::Hybrid; }
     bool isThumbnailWidget() { return displayMode == DisplayMode::Thumbnail; }
 
+    void setLoadTrackEnabled(bool enabled)
+    {
+        for (auto& m : mediaDisplays)
+        {
+            m->setChooseFileButtonEnabled(enabled);
+        }
+    }
+
     bool isInterestedInFileDrag(const StringArray& /*files*/) override
     {
         return isThumbnailWidget();


### PR DESCRIPTION
This PR fixes issue #374 by preventing the Open File operation from occurring while tracks are processing.

Instead of explicitly disabling or greying out the button, the implementation follows the existing UI pattern used for the save button in `MediaDisplayComponent.cpp`. 