### PR TITLE
MIDI Drum Visualization and Windows Build Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,14 +212,16 @@ if (WIN32)
         )
 
         # Set the base path for Visual Studio 2022 redistributable DLLs
-        set(VS_CRT_BASE_PATH "C:/Program Files/Microsoft Visual Studio/2022/*/VC/Redist/MSVC/*/x64/Microsoft.VC143.CRT")
+        set(VS_CRT_BASE_PATH
+		    "C:/Program Files/Microsoft Visual Studio/2022/*/VC/Redist/MSVC/*/x64/Microsoft.VC143.CRT"
+		    "C:/Program Files (x86)/Microsoft Visual Studio/2022/*/VC/Redist/MSVC/*/x64/Microsoft.VC143.CRT"
+		    )
 
         # Search for the DLLs in the specified base path
         file(GLOB_RECURSE all_runtime_dlls
-            LIST_DIRECTORIES false
-            "${VS_CRT_BASE_PATH}/*.dll"
+                LIST_DIRECTORIES false
+                ${VS_CRT_BASE_PATH}/*.dll
         )
-
         set(runtime_dlls)
 
         foreach(dll ${all_runtime_dlls})

--- a/src/media/MidiDisplayComponent.cpp
+++ b/src/media/MidiDisplayComponent.cpp
@@ -96,10 +96,9 @@ void MidiDisplayComponent::loadMediaFile(const URL& filePath)
 
         int channel = midiMessage.getChannel();
 
-        if (channel == 10)
-        {
-            // TODO - handle drums channel
-        }
+        // Handle drums channel
+        bool isDrum = (channel == 10);
+
 
         if (midiMessage.isProgramChange())
         {
@@ -137,7 +136,8 @@ void MidiDisplayComponent::loadMediaFile(const URL& filePath)
                                   startTime,
                                   duration,
                                   static_cast<unsigned char>(velocity),
-                                  static_cast<unsigned char>(instrument));
+                                  static_cast<unsigned char>(instrument),
+                                  isDrum);
             pianoRoll.insertNote(n);
         }
     }

--- a/src/media/pianoroll/NoteGridComponent.cpp
+++ b/src/media/pianoroll/NoteGridComponent.cpp
@@ -27,26 +27,46 @@ void NoteGridComponent::paint(Graphics& g)
 
         Rectangle<float> bounds(noteXPos, noteYPos, jmax(3.0f, noteWidth), noteHeight - 1.0f);
 
+        float maxDrumWidth = 0.01f * getParentComponent()->getWidth();
+
         float hue = static_cast<float>(n->instrument) / 127.0f;
 
         Colour color = Colour::fromHSV(hue, 1.0f, 1.0f, 1.0f).brighter();
 
         // Note fill
-        g.setColour(color.withAlpha(0.75f));
-        g.fillRect(bounds.toNearestInt());
-
-        if ((noteWidth >= 5) & (noteHeight >= 8))
+        
+        if (n->isDrum)
         {
-            const float maxVelocityWidth = static_cast<float>(noteWidth - 4);
-            const float verticalOffset = static_cast<float>(noteHeight) * 0.5f - 2.0f;
-            const float velocityHeight = 4.0f;
+            g.setColour(color);
 
-            // Velocity fill
-            g.setColour(color.brighter());
-            g.fillRect(bounds.translated(2, verticalOffset)
-                           .withWidth(maxVelocityWidth * n->velocity / 127.0f)
-                           .withHeight(velocityHeight)
-                           .toNearestInt());
+            const float thickness = jmax(2.0f, noteHeight * 0.18f);
+            const float pad = jmax(1.0f, thickness * 0.5f);
+
+            const float x1 = noteXPos - maxDrumWidth/2;
+            const float y1 = bounds.getY() + pad;
+            const float x2 = noteXPos + maxDrumWidth/2;
+            const float y2 = bounds.getBottom() - pad;
+
+            g.drawLine(x1, y1, x2, y2, thickness);
+            g.drawLine(x2, y1, x1, y2, thickness);
+        }
+        else
+        {
+            g.setColour(color.withAlpha(0.75f));
+            g.fillRect(bounds.toNearestInt());
+
+            if ((noteWidth >= 5) && (noteHeight >= 8))
+            {
+                const float maxVelocityWidth = static_cast<float>(noteWidth - 4);
+                const float verticalOffset = static_cast<float>(noteHeight) * 0.5f - 2.0f;
+                const float velocityHeight = 4.0f;
+
+                g.setColour(color.brighter());
+                g.fillRect(bounds.translated(2, verticalOffset)
+                               .withWidth(maxVelocityWidth * n->velocity / 127.0f)
+                               .withHeight(velocityHeight)
+                               .toNearestInt());
+            }
         }
     }
 }

--- a/src/media/pianoroll/NoteGridComponent.hpp
+++ b/src/media/pianoroll/NoteGridComponent.hpp
@@ -15,8 +15,8 @@ using namespace juce;
 struct MidiNote
 {
 public:
-    MidiNote(unsigned char n, double s, double d, unsigned char v, unsigned char i = 0)
-        : noteNumber(n), startTime(s), duration(d), velocity(v), instrument(i)
+    MidiNote(unsigned char n, double s, double d, unsigned char v, unsigned char i = 0, bool drum = false)
+        : noteNumber(n), startTime(s), duration(d), velocity(v), instrument(i), isDrum(drum)
     {
     }
 
@@ -27,6 +27,7 @@ public:
         duration = other.duration;
         velocity = other.velocity;
         instrument = other.instrument;
+        isDrum = other.isDrum;
     }
 
     unsigned char noteNumber;
@@ -34,6 +35,7 @@ public:
     double duration;
     unsigned char velocity;
     unsigned char instrument;
+    bool isDrum;
 };
 
 class NoteGridComponent : public KeyboardComponent


### PR DESCRIPTION
Summary:
- Implements drum-aware MIDI visualization
- Adds drum-note flag to MIDI notes
- Identifies channel 10 MIDI notes as drums
- Renders drum notes as X markers in the piano roll

Additional Fix:
- Fixes Windows runtime DLL path detection for Visual Studio BuildTools installs

Context:
- While implementing Drum MIDI Visualization on Windows, I encountered a runtime DLL path issue that prevented the application from running correctly
- This fix was made in order to proceed with development and was included as an addition

Notes:
- Drum changes are visualization only
- No synthesis/audio behavior was modified (we agreed that this was already sufficiently handled by https://huggingface.co/spaces/teamup-tech/midi-synthesizer)
- For Windows DLL path fix; will open a follow-up ticket to make VS detection more robust