### PR TITLE
Export Labels to JSON button / Retain Label State (Progress on #283 and #414)

### DIFF
--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -253,6 +253,27 @@ void MediaDisplayComponent::initializeButtons()
     copyFileButton.addMode(copyFileButtonInactiveInfo);
     headerComponent.addAndMakeVisible(copyFileButton);
 
+    // RZ: Save labels button
+   // Mode when labels exist
+    saveLabelsButtonActiveInfo = MultiButton::Mode { "SaveLabels-Active",
+                                                   "Click to export labels to JSON.",
+                                                   [this] { saveLabelsCallback(); },
+                                                   MultiButton::DrawingMode::IconOnly,
+                                                   Colours::lightgreen, // Colored green to distinguish from media save
+                                                   fontawesome::Save };
+    // Mode when no labels exist
+    saveLabelsButtonInactiveInfo = MultiButton::Mode { "SaveLabels-Inactive",
+                                                       "No labels to save.",
+                                                       [this] {},
+                                                       MultiButton::DrawingMode::IconOnly,
+                                                       Colours::lightgrey,
+                                                       fontawesome::Save };
+    saveLabelsButton.addMode(saveLabelsButtonActiveInfo);
+    saveLabelsButton.addMode(saveLabelsButtonInactiveInfo);
+    headerComponent.addAndMakeVisible(saveLabelsButton); 
+
+    saveLabelsButton.setVisible(false); // RZ: Hide the button initially
+
     resetButtonState();
 }
 
@@ -399,6 +420,12 @@ void MediaDisplayComponent::resized()
     {
         buttonsFlexBox.items.add(
             FlexItem(saveFileButton).withHeight(25).withWidth(25).withMargin({ 2, 0, 2, 0 }));
+
+        if (currentLabelsJson.isNotEmpty()) // RZ: Show save labels button only if there are labels to save
+        {
+            buttonsFlexBox.items.add(
+                FlexItem(saveLabelsButton).withHeight(25).withWidth(25).withMargin({ 2, 0, 2, 0 }));
+        }
         buttonsFlexBox.items.add(
             FlexItem(copyFileButton).withHeight(25).withWidth(25).withMargin({ 2, 0, 2, 0 }));
     }
@@ -1491,6 +1518,55 @@ void MediaDisplayComponent::addLabels(const LabelList& labels)
             addOverheadLabel(ol);
         }
     }
+    // RZ: Generate JSON representation of labels for export
+    juce::Array<juce::var> labelArray;
+    for (const auto& l : labels)
+    {
+        if (!shouldRenderLabel(l)) continue;
+        
+        juce::DynamicObject::Ptr labelObj = new juce::DynamicObject();
+        labelObj->setProperty("t", l->t);
+        labelObj->setProperty("label", l->label);
+
+        if (l->duration.has_value()) labelObj->setProperty("duration", l->duration.value());
+        if (l->description.has_value()) labelObj->setProperty("description", l->description.value());
+        if (l->color.has_value()) labelObj->setProperty("color", l->color.value());
+        if (l->link.has_value()) labelObj->setProperty("link", l->link.value());
+
+        if (auto* audioLabel = dynamic_cast<AudioLabel*>(l.get()))
+        {
+            labelObj->setProperty("label_type", "AudioLabel");
+            if (audioLabel->amplitude.has_value()) labelObj->setProperty("amplitude", audioLabel->amplitude.value());
+        }
+        else if (auto* midiLabel = dynamic_cast<MidiLabel*>(l.get()))
+        {
+            labelObj->setProperty("label_type", "MidiLabel");
+            if (midiLabel->pitch.has_value()) labelObj->setProperty("pitch", midiLabel->pitch.value());
+        }
+        else if (auto* specLabel = dynamic_cast<SpectrogramLabel*>(l.get()))
+        {
+            labelObj->setProperty("label_type", "SpectrogramLabel");
+            if (specLabel->frequency.has_value()) labelObj->setProperty("frequency", specLabel->frequency.value());
+        }
+        else
+        {
+            labelObj->setProperty("label_type", "OutputLabel");
+        }
+
+        labelArray.add(juce::var(labelObj));
+    }
+
+    juce::DynamicObject::Ptr rootObj = new juce::DynamicObject();
+    rootObj->setProperty("labels", juce::var(labelArray));
+    currentLabelsJson = juce::JSON::toString(juce::var(rootObj));
+
+    // Activate the button if we successfully generated labels
+    if (!labelArray.isEmpty()) {
+        saveLabelsButton.setMode(saveLabelsButtonActiveInfo.displayLabel);
+
+        saveLabelsButton.setVisible(true); // RZ: Show the button when there are labels to save
+        resized(); // RZ: Update layout to accommodate button
+    }
 }
 
 void MediaDisplayComponent::clearLabels(int processingIdxCutoff)
@@ -1523,7 +1599,25 @@ void MediaDisplayComponent::clearLabels(int processingIdxCutoff)
     if (! processingIdxCutoff)
     {
         overheadLabels.clear();
+        currentLabelsJson.clear(); // CLEAR CACHE
+        saveLabelsButton.setMode(saveLabelsButtonInactiveInfo.displayLabel); // DEACTIVATE BUTTON
+        saveLabelsButton.setVisible(false); // RZ: Hide the button when there are no labels to save
     }
 
     resized(); // Remove overhead label panel
+}
+
+void MediaDisplayComponent::saveLabelsCallback()
+{
+    if (currentLabelsJson.isEmpty())
+        return;
+
+    juce::File outputFile("/Users/richardzhu/Library/Caches/HARP/labels.json");
+    outputFile.getParentDirectory().createDirectory();
+    outputFile.replaceWithText(currentLabelsJson);
+
+    if (statusMessage != nullptr)
+    {
+        statusMessage->setMessage("Labels exported to " + outputFile.getFullPathName());
+    }
 }

--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -6,6 +6,9 @@
 
 #include <cmath>
 
+// RZ: Initialize JUCE SafePointer for drag-and-drop label creation
+Component::SafePointer<MediaDisplayComponent> MediaDisplayComponent::currentlyDraggedComponent = nullptr;
+
 namespace
 {
 struct TickScheme
@@ -1346,6 +1349,10 @@ void MediaDisplayComponent::mouseDrag(const MouseEvent& e)
         {
             //performExternalDragDropOfFiles(
             //    StringArray(getTempFilePath().getLocalFile().getFullPathName()), true, this);
+
+            // RZ: Set the tracker before the blocking OS drag
+            currentlyDraggedComponent = this;
+
             performExternalDragDropOfFiles(
                 StringArray(getOriginalFilePath().getLocalFile().getFullPathName()), true, this);
         }
@@ -1447,6 +1454,11 @@ void MediaDisplayComponent::removeLabelOverlay(LabelOverlayComponent* l)
 
 void MediaDisplayComponent::addLabels(const LabelList& labels)
 {
+    // RZ: save a copy of the incoming labels
+    for (const auto& l : labels) {
+        cachedLabels.push_back(l->clone());
+    }
+    
     for (const auto& l : labels)
     {
         if (! shouldRenderLabel(l))
@@ -1600,6 +1612,7 @@ void MediaDisplayComponent::clearLabels(int processingIdxCutoff)
     {
         overheadLabels.clear();
         currentLabelsJson.clear(); // CLEAR CACHE
+        cachedLabels.clear(); // RZ: Clear memory cache
         saveLabelsButton.setMode(saveLabelsButtonInactiveInfo.displayLabel); // DEACTIVATE BUTTON
         saveLabelsButton.setVisible(false); // RZ: Hide the button when there are no labels to save
     }

--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -1607,17 +1607,50 @@ void MediaDisplayComponent::clearLabels(int processingIdxCutoff)
     resized(); // Remove overhead label panel
 }
 
-void MediaDisplayComponent::saveLabelsCallback()
+void MediaDisplayComponent::saveLabelsCallback() // RZ: Callback for saving labels
 {
     if (currentLabelsJson.isEmpty())
         return;
 
-    juce::File outputFile("/Users/richardzhu/Library/Caches/HARP/labels.json");
-    outputFile.getParentDirectory().createDirectory();
-    outputFile.replaceWithText(currentLabelsJson);
+    // 1. Initialize the file chooser with a default name "labels.json"
+    saveLabelsBrowser = std::make_unique<juce::FileChooser>(
+        "Select a save path for labels...", 
+        juce::File::getSpecialLocation(juce::File::userDocumentsDirectory).getChildFile("labels.json"), 
+        "*.json");
 
-    if (statusMessage != nullptr)
-    {
-        statusMessage->setMessage("Labels exported to " + outputFile.getFullPathName());
-    }
+    // 2. Launch the dialog asynchronously
+    saveLabelsBrowser->launchAsync(
+        juce::FileBrowserComponent::saveMode | juce::FileBrowserComponent::canSelectFiles,
+        [this](const juce::FileChooser& fc)
+        {
+            juce::File chosenFile = fc.getResult();
+            
+            // 3. If the user didn't cancel the dialog...
+            if (chosenFile != juce::File{})
+            {
+                // Ensure it ends with .json
+                if (!chosenFile.hasFileExtension(".json"))
+                {
+                    chosenFile = chosenFile.withFileExtension(".json");
+                }
+
+                // 4. Attempt to write the text to the chosen file
+                if (chosenFile.replaceWithText(currentLabelsJson))
+                {
+                    if (statusMessage != nullptr)
+                    {
+                        statusMessage->setMessage("Labels successfully exported to " + chosenFile.getFullPathName());
+                    }
+                }
+                else
+                {
+                    // Display an error popup if writing to the disk fails
+                    juce::AlertWindow::showMessageBoxAsync(
+                        juce::AlertWindow::WarningIcon,
+                        "Save Failed",
+                        "Failed to save labels to " + chosenFile.getFullPathName() + ".",
+                        "OK");
+                }
+            }
+        });
 }

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -303,6 +303,7 @@ private:
 
     std::unique_ptr<FileChooser> chooseFileBrowser;
     std::unique_ptr<FileChooser> saveFileBrowser;
+    std::unique_ptr<FileChooser> saveLabelsBrowser; // RZ: File chooser for saving labels
 
     double horizontalZoomFactor;
     ScrollBar horizontalScrollBar { false };

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -159,6 +159,18 @@ public:
     void addLabels(const LabelList& labels);
     void clearLabels(int processingIdxCutoff = 0);
 
+    // RZ: JUCE SafePointer to the currently dragged component, used for drag-and-drop label creation
+    static Component::SafePointer<MediaDisplayComponent> currentlyDraggedComponent;
+    
+    // Returns a fresh, deep-copied list of this track's labels
+    LabelList getClonedLabels() const
+    {
+        LabelList clones;
+        for (const auto& l : cachedLabels)
+            clones.push_back(l->clone());
+        return clones;
+    }
+
 protected:
     void resetTransport();
 
@@ -318,4 +330,6 @@ private:
 
     SharedResourcePointer<InstructionsMessage> instructionsMessage;
     SharedResourcePointer<StatusMessage> statusMessage;
+    
+    LabelList cachedLabels; // RZ: Cache of this track's labels
 };

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -125,6 +125,8 @@ public:
 
     void saveFileCallback();
     void copyFileCallback();
+    void saveLabelsCallback(); // RZ: Callback for saving labels
+    String currentLabelsJson; // Stores the serialized JSON string for this track
 
     virtual double getTotalLengthInSecs() = 0;
     virtual double getTimeAtOrigin() { return visibleRange.getStart(); }
@@ -271,6 +273,9 @@ private:
     MultiButton copyFileButton;
     MultiButton::Mode copyFileButtonActiveInfo;
     MultiButton::Mode copyFileButtonInactiveInfo;
+    MultiButton saveLabelsButton; // RZ: Save labels button
+    MultiButton::Mode saveLabelsButtonActiveInfo;
+    MultiButton::Mode saveLabelsButtonInactiveInfo;
 
     // Panel displaying overhead labels
     ColorablePanel overheadPanel { overheadPanelColor };

--- a/src/utils/Labels.h
+++ b/src/utils/Labels.h
@@ -9,38 +9,70 @@
 #include <juce_core/juce_core.h>
 
 using namespace juce;
-
+// RZ: include cloning capabilities in structs to allow copying of polymorphic objects in LabelList without slicing issues.
 struct OutputLabel
 {
-    // Required fields
     float t;
     String label;
-
-    // Optional fields
     std::optional<String> description;
     std::optional<float> duration;
     std::optional<int> color;
     std::optional<String> link;
 
-    virtual ~OutputLabel() = default; // Virtual destructor
+    virtual ~OutputLabel() = default;
+
+    // ADD THIS TO BASE STRUCT
+    virtual std::unique_ptr<OutputLabel> clone() const
+    {
+        auto copy = std::make_unique<OutputLabel>();
+        copyBaseFields(copy.get());
+        return copy;
+    }
+
+protected:
+    void copyBaseFields(OutputLabel* copy) const
+    {
+        copy->t = t; copy->label = label; copy->description = description;
+        copy->duration = duration; copy->color = color; copy->link = link;
+    }
 };
 
 struct AudioLabel : public OutputLabel
 {
-    // Additional fields
     std::optional<float> amplitude;
+    // ADD THIS
+    std::unique_ptr<OutputLabel> clone() const override {
+        auto copy = std::make_unique<AudioLabel>();
+        copyBaseFields(copy.get());
+        copy->amplitude = amplitude;
+        return copy;
+    }
 };
 
 struct SpectrogramLabel : public OutputLabel
 {
-    // Additional fields
     std::optional<float> frequency;
+    // ADD THIS
+    std::unique_ptr<OutputLabel> clone() const override {
+        auto copy = std::make_unique<SpectrogramLabel>();
+        copyBaseFields(copy.get());
+        copy->frequency = frequency;
+        return copy;
+    }
 };
 
 struct MidiLabel : public OutputLabel
 {
-    // Additional fields
     std::optional<float> pitch;
+    // ADD THIS
+    std::unique_ptr<OutputLabel> clone() const override {
+        auto copy = std::make_unique<MidiLabel>();
+        copyBaseFields(copy.get());
+        copy->pitch = pitch;
+        return copy;
+    }
 };
 
 using LabelList = std::vector<std::unique_ptr<OutputLabel>>;
+
+

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -341,8 +341,25 @@ public:
         for (String f : files)
         {
             URL droppedFilePath = URL(File(f));
-
             addTrackFromFilePath(droppedFilePath);
+            
+            // RZ: update the clipboard to look for that static pointer when a file is dropped.
+            if (MediaDisplayComponent::currentlyDraggedComponent != nullptr)
+            {
+                // Verify the file paths match to ensure we are applying labels to the correct track
+                if (MediaDisplayComponent::currentlyDraggedComponent->getOriginalFilePath() == droppedFilePath)
+                {
+                    if (!mediaDisplays.empty())
+                    {
+                        // Get the newly created track in the clipboard
+                        auto* newTrack = mediaDisplays.back().get();
+                        
+                        // Deep copy the labels over!
+                        newTrack->addLabels(MediaDisplayComponent::currentlyDraggedComponent->getClonedLabels());
+                    }
+                }
+                MediaDisplayComponent::currentlyDraggedComponent = nullptr; // RZ: Clear the tracker when the drag finishes
+            }
         }
     }
 


### PR DESCRIPTION
### Current Progress on Issue #283 and #414
- Clicking the export button now opens a button for the user to select where to save the JSON file.
- Files dragged from output track to media clipboard now retain their label status.
 
### Still to figure out for Issue-283:

- [ ] Where should the button go?
- It currently only shows up if labels are present in the output track
- [ ] How should we name JSON, especially for multi-output models (currently all labels.json)?