### PR TITLE
Issue 422 (Drag to reorder bugs on Windows and MacOS)

### DIFF
--- a/src/MainComponent.h
+++ b/src/MainComponent.h
@@ -31,6 +31,7 @@ class WelcomeWindow;
 class MainComponent : public Component,
                       public MenuBarModel,
                       public ApplicationCommandTarget,
+                      public DragAndDropContainer,
                       private ChangeListener
 
 {

--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -1337,7 +1337,7 @@ void MediaDisplayComponent::mouseDrag(const MouseEvent& e)
                 {
                     container->performExternalDragDropOfFiles(
                         StringArray(getOriginalFilePath().getLocalFile().getFullPathName()),
-                        true,
+                        false,
                         this);
                 }
             }

--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -1317,10 +1317,30 @@ void MediaDisplayComponent::mouseDrag(const MouseEvent& e)
 
         if (! getLocalBounds().contains(getMouseXYRelative()))
         {
-            //performExternalDragDropOfFiles(
-            //    StringArray(getTempFilePath().getLocalFile().getFullPathName()), true, this);
-            performExternalDragDropOfFiles(
-                StringArray(getOriginalFilePath().getLocalFile().getFullPathName()), true, this);
+            Component* topLevel = getTopLevelComponent();
+            Rectangle<int> appBounds =
+                topLevel != nullptr ? topLevel->getScreenBounds() : Rectangle<int>();
+            Point<int> screenPos = localPointToGlobal(getMouseXYRelative());
+
+            // if the cursor goes outside the HARP window
+            if (auto* container = DragAndDropContainer::findParentDragContainerFor(this))
+            {
+                if (appBounds.contains(screenPos)) // use internal JUCE drag inside window
+                {
+                    if (!container->isDragAndDropActive())
+                    {
+                        container->startDragging(
+                            getOriginalFilePath().getLocalFile().getFullPathName(), this, ScaledImage{}, false);
+                    }
+                }
+                else // use OS file drag outside window
+                {
+                    container->performExternalDragDropOfFiles(
+                        StringArray(getOriginalFilePath().getLocalFile().getFullPathName()),
+                        true,
+                        this);
+                }
+            }
         }
 
         updateCursorPosition();

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -62,8 +62,8 @@ private:
 class MediaDisplayComponent : public Component,
                               public ChangeListener,
                               public ChangeBroadcaster,
+                              public DragAndDropTarget,
                               public FileDragAndDropTarget,
-                              public DragAndDropContainer,
                               private Timer,
                               private ScrollBar::Listener
 {
@@ -120,6 +120,20 @@ public:
     //void overwriteOriginalFile(); // Necessary for seamless sample editing integration
 
     bool isInterestedInFileDrag(const StringArray& /*files*/) override { return isInputTrack(); }
+
+    bool isInterestedInDragSource(const DragAndDropTarget::SourceDetails& details) override
+    {
+        return isInputTrack() && details.description.isString();
+    }
+
+    void itemDropped(const DragAndDropTarget::SourceDetails& details) override
+    {
+        String filePath = details.description.toString();
+        if (filePath.isNotEmpty())
+        {
+            initializeDisplay(URL(File(filePath)));
+        }
+    }
 
     bool isDuplicateFile(const URL& fileParth);
 

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -615,12 +615,10 @@ private:
         if (!isThumbnailWidget() || draggedTrack == nullptr) return;
 
         Point<int> posInThis = e.getEventRelativeTo(this).getPosition();
-        DBG_AND_LOG("mouseDrag called, pos: " << posInThis.x << ", " << posInThis.y);
 
         if (!isDraggingTrack && e.getDistanceFromDragStart() > 5)
         {
             isDraggingTrack = true;
-            DBG_AND_LOG("drag started");
 
             // Takes a snapshot of the track at the moment dragging starts
             if (dragOverlay != nullptr)
@@ -634,7 +632,6 @@ private:
 
         if (isDraggingTrack)
         {
-            DBG_AND_LOG("isDraggingTrack true, processing...");
             int newInsertIndex = -1;
             bool wasOutside = isDraggingOutside;
 
@@ -666,7 +663,6 @@ private:
 
     void mouseUp(const MouseEvent& e) override
     {
-        DBG_AND_LOG("mouseUp called, isDraggingTrack: " << (int)isDraggingTrack);
         if (!isThumbnailWidget()) return;
 
         // Tracks the release position of the mouse

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -615,10 +615,12 @@ private:
         if (!isThumbnailWidget() || draggedTrack == nullptr) return;
 
         Point<int> posInThis = e.getEventRelativeTo(this).getPosition();
+        DBG_AND_LOG("mouseDrag called, pos: " << posInThis.x << ", " << posInThis.y);
 
         if (!isDraggingTrack && e.getDistanceFromDragStart() > 5)
         {
             isDraggingTrack = true;
+            DBG_AND_LOG("drag started");
 
             // Takes a snapshot of the track at the moment dragging starts
             if (dragOverlay != nullptr)
@@ -632,6 +634,7 @@ private:
 
         if (isDraggingTrack)
         {
+            DBG_AND_LOG("isDraggingTrack true, processing...");
             int newInsertIndex = -1;
             bool wasOutside = isDraggingOutside;
 
@@ -663,6 +666,7 @@ private:
 
     void mouseUp(const MouseEvent& e) override
     {
+        DBG_AND_LOG("mouseUp called, isDraggingTrack: " << (int)isDraggingTrack);
         if (!isThumbnailWidget()) return;
 
         // Tracks the release position of the mouse


### PR DESCRIPTION
Drag and drop to reorder files worked improperly on Windows and MacOS. This was due to the mouse events for the reorder getting interrupted by the ones for dragging files into and out of HARP from external applications (like file explorer), so this fix includes a little rewriting of that logic. Curiously, MediaDisplayComponent had inherited from the JUCE drag and drop internal class but didn't use it, implying that there was some logic that should have existed to make dragging tracks from the media clipboard into an input track distinct from the OS file drags, but wasn't fully implemented (?). I essentially drag operations into 3 scopes: one within the TrackAreaWidget (reorder and draw a gap at the destination), one within HARP but outside the TrackAreaWidget (draw a ghost in the original location, since the intention is to drag to an input track), and one outside HARP entirely, which invokes the external drag-in and drag-out logic. On drag-out, files are copied instead of moved.
This works nicely on Windows and Linux, with the only issues being a strange ghosting that occurs on Windows (and _not_ on Linux) when tracks are placed (on mouseUp). 

This has not yet been tested on MacOS; if someone could do that and let me know, that would be great. (I'll mention this at a meeting)

Aside: I can't confirm if drag in and drag out of HARP work on Linux because, as before, those functions never worked on my particular version of Ubuntu to begin with. That's on the docket for... eventually.