### PR TITLE
Support for Generic Inputs and Outputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ target_sources(${PROJECT_NAME}
         src/gui/HoverHandler.h
         src/gui/ControlComponent.h
         src/gui/ToggleWithLabel.h
+        src/gui/FilePickerWithLabel.h
 
         src/media/MediaDisplayComponent.cpp
         src/media/AudioDisplayComponent.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ target_sources(${PROJECT_NAME}
         src/gui/HoverHandler.h
         src/gui/ControlComponent.h
         src/gui/ToggleWithLabel.h
-        src/gui/FilePickerWithLabel.h
+        src/gui/FileChooserWithLabel.h
 
         src/media/MediaDisplayComponent.cpp
         src/media/AudioDisplayComponent.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ target_sources(${PROJECT_NAME}
         src/media/MediaDisplayComponent.cpp
         src/media/AudioDisplayComponent.cpp
         src/media/MidiDisplayComponent.cpp
+        src/media/FileDisplayComponent.cpp
         src/media/OutputLabelComponent.cpp
 
         src/media/pianoroll/KeyboardComponent.cpp

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The currently available versions of HARP and pyharp are mutually compatible.
 <!-- website/content/contributing/add_model.md -->
 # Adding Models with pyharp
 
-[![ReadMe Card](https://github-readme-stats.vercel.app/api/pin/?username=TEAMuP-dev&repo=pyharp)](https://github.com/TEAMuP-dev/pyharp)
+[![PyHARP](https://gh-card.dev/repos/TEAMuP-dev/pyharp.svg)](https://github.com/TEAMuP-dev/pyharp)
 
 pyharp provides a lightweight API to build HARP-compatible [Gradio](https://www.gradio.app) apps. It allows researchers to easily create DAW-friendly interfaces for any audio processing code with minimal Python wrapping.
 

--- a/src/Model.h
+++ b/src/Model.h
@@ -440,6 +440,18 @@ private:
                     DBG_AND_LOG("Model::extractInputs: MIDI track input \"" + midiTrack->label
                                 + "\" extracted.");
                 }
+                // Generic File
+                else if (type == "file_track")
+                {
+                    std::shared_ptr<ModelComponentInfo> fileTrack =
+                        std::make_shared<FileTrackComponentInfo>(controlsDict);
+
+                    newInputs.push_back(fileTrack);
+                    tempComponentIDs.push_back(fileTrack->id);
+
+                    DBG_AND_LOG("Model::extractInputs: File track input \"" + fileTrack->label
+                                + "\" extracted.");
+                }
                 else if (type == "text_box")
                 {
                     std::shared_ptr<ModelComponentInfo> textControl =
@@ -561,6 +573,17 @@ private:
                     newOutputs.push_back(midiTrack);
 
                     DBG_AND_LOG("Model::extractOutputs: MIDI track output \"" + midiTrack->label
+                                + "\" extracted.");
+                }
+                // Generic File
+                else if (type == "file_track")
+                {
+                    std::shared_ptr<ModelComponentInfo> fileTrack =
+                        std::make_shared<FileTrackComponentInfo>(controlsDict);
+
+                    newOutputs.push_back(fileTrack);
+
+                    DBG_AND_LOG("Model::extractOutputs: File track output \"" + fileTrack->label
                                 + "\" extracted.");
                 }
                 else if (type == "json")

--- a/src/Model.h
+++ b/src/Model.h
@@ -259,6 +259,32 @@ public:
             }
         }
 
+        std::map<Uuid, std::string> fileControlRemotePaths;
+
+        for (const auto& controlComponent : controlComponents)
+        {
+            if (auto* fileComponentInfo =
+                    dynamic_cast<FileComponentInfo*>(controlComponent.get()))
+            {
+                if (fileComponentInfo->path.empty())
+                    continue;
+
+                String remoteFilePath;
+
+                result = client->uploadFile(
+                    loadedPath, File(fileComponentInfo->path), remoteFilePath);
+
+                if (result.failed())
+                {
+                    setStatus(ModelStatus::FAILURE);
+
+                    return result;
+                }
+
+                fileControlRemotePaths[fileComponentInfo->id] = remoteFilePath.toStdString();
+            }
+        }
+
         /* Extract control values for JSON payload in order */
 
         Array<var> controlValues;
@@ -316,7 +342,9 @@ public:
             }
             else if (auto fileComponentInfo = dynamic_cast<FileComponentInfo*>(componentInfo.get()))
             {
-                if (fileComponentInfo->path.empty())
+                auto it = fileControlRemotePaths.find(fileComponentInfo->id);
+
+                if (it == fileControlRemotePaths.end() || it->second.empty())
                 {
                     controlValue = var();
                 }
@@ -324,7 +352,7 @@ public:
                 {
                     DynamicObject::Ptr fileObj = new DynamicObject();
 
-                    fileObj->setProperty("path", var(fileComponentInfo->path));
+                    fileObj->setProperty("path", var(it->second));
 
                     controlValue = var(fileObj);
                 }

--- a/src/Model.h
+++ b/src/Model.h
@@ -263,16 +263,15 @@ public:
 
         for (const auto& controlComponent : controlComponents)
         {
-            if (auto* fileComponentInfo =
-                    dynamic_cast<FileComponentInfo*>(controlComponent.get()))
+            if (auto* fileComponentInfo = dynamic_cast<FileComponentInfo*>(controlComponent.get()))
             {
                 if (fileComponentInfo->path.empty())
                     continue;
 
                 String remoteFilePath;
 
-                result = client->uploadFile(
-                    loadedPath, File(fileComponentInfo->path), remoteFilePath);
+                result =
+                    client->uploadFile(loadedPath, File(fileComponentInfo->path), remoteFilePath);
 
                 if (result.failed())
                 {
@@ -621,7 +620,13 @@ private:
                 }
                 else if (type == "generic_file")
                 {
-                    // TODO
+                    std::shared_ptr<ModelComponentInfo> fileOutput =
+                        std::make_shared<FileComponentInfo>(controlsDict);
+
+                    newOutputs.push_back(fileOutput);
+
+                    DBG_AND_LOG("Model::extractOutputs: File output \"" + fileOutput->label
+                                + "\" extracted.");
                 }
                 else if (type == "json")
                 {

--- a/src/Model.h
+++ b/src/Model.h
@@ -314,6 +314,22 @@ public:
             {
                 controlValue = var(comboBoxComponentInfo->value);
             }
+            else if (auto filePickerComponentInfo =
+                         dynamic_cast<FilePickerComponentInfo*>(componentInfo.get()))
+            {
+                if (filePickerComponentInfo->path.empty())
+                {
+                    controlValue = var();
+                }
+                else
+                {
+                    DynamicObject::Ptr fileObj = new DynamicObject();
+                    fileObj->setProperty("path", var(filePickerComponentInfo->path));
+                    controlValue = var(fileObj);
+                }
+
+                wasFile = true;
+            }
             else
             {
                 // Unsupported control was added
@@ -441,15 +457,15 @@ private:
                                 + "\" extracted.");
                 }
                 // Generic File
-                else if (type == "file_track")
+                else if (type == "file_picker")
                 {
-                    std::shared_ptr<ModelComponentInfo> fileTrack =
-                        std::make_shared<FileTrackComponentInfo>(controlsDict);
+                    std::shared_ptr<ModelComponentInfo> filePicker =
+                        std::make_shared<FilePickerComponentInfo>(controlsDict);
 
-                    newInputs.push_back(fileTrack);
-                    tempComponentIDs.push_back(fileTrack->id);
+                    newControls.push_back(filePicker);
+                    tempComponentIDs.push_back(filePicker->id);
 
-                    DBG_AND_LOG("Model::extractInputs: File track input \"" + fileTrack->label
+                    DBG_AND_LOG("Model::extractInputs: File picker control \"" + filePicker->label
                                 + "\" extracted.");
                 }
                 else if (type == "text_box")
@@ -573,17 +589,6 @@ private:
                     newOutputs.push_back(midiTrack);
 
                     DBG_AND_LOG("Model::extractOutputs: MIDI track output \"" + midiTrack->label
-                                + "\" extracted.");
-                }
-                // Generic File
-                else if (type == "file_track")
-                {
-                    std::shared_ptr<ModelComponentInfo> fileTrack =
-                        std::make_shared<FileTrackComponentInfo>(controlsDict);
-
-                    newOutputs.push_back(fileTrack);
-
-                    DBG_AND_LOG("Model::extractOutputs: File track output \"" + fileTrack->label
                                 + "\" extracted.");
                 }
                 else if (type == "json")

--- a/src/Model.h
+++ b/src/Model.h
@@ -314,17 +314,18 @@ public:
             {
                 controlValue = var(comboBoxComponentInfo->value);
             }
-            else if (auto filePickerComponentInfo =
-                         dynamic_cast<FilePickerComponentInfo*>(componentInfo.get()))
+            else if (auto fileComponentInfo = dynamic_cast<FileComponentInfo*>(componentInfo.get()))
             {
-                if (filePickerComponentInfo->path.empty())
+                if (fileComponentInfo->path.empty())
                 {
                     controlValue = var();
                 }
                 else
                 {
                     DynamicObject::Ptr fileObj = new DynamicObject();
-                    fileObj->setProperty("path", var(filePickerComponentInfo->path));
+
+                    fileObj->setProperty("path", var(fileComponentInfo->path));
+
                     controlValue = var(fileObj);
                 }
 
@@ -456,16 +457,15 @@ private:
                     DBG_AND_LOG("Model::extractInputs: MIDI track input \"" + midiTrack->label
                                 + "\" extracted.");
                 }
-                // Generic File
-                else if (type == "file_picker")
+                else if (type == "generic_file")
                 {
-                    std::shared_ptr<ModelComponentInfo> filePicker =
-                        std::make_shared<FilePickerComponentInfo>(controlsDict);
+                    std::shared_ptr<ModelComponentInfo> fileChooser =
+                        std::make_shared<FileComponentInfo>(controlsDict);
 
-                    newControls.push_back(filePicker);
-                    tempComponentIDs.push_back(filePicker->id);
+                    newControls.push_back(fileChooser);
+                    tempComponentIDs.push_back(fileChooser->id);
 
-                    DBG_AND_LOG("Model::extractInputs: File picker control \"" + filePicker->label
+                    DBG_AND_LOG("Model::extractInputs: File chooser control \"" + fileChooser->label
                                 + "\" extracted.");
                 }
                 else if (type == "text_box")
@@ -590,6 +590,10 @@ private:
 
                     DBG_AND_LOG("Model::extractOutputs: MIDI track output \"" + midiTrack->label
                                 + "\" extracted.");
+                }
+                else if (type == "generic_file")
+                {
+                    // TODO
                 }
                 else if (type == "json")
                 {

--- a/src/ModelTab.h
+++ b/src/ModelTab.h
@@ -487,6 +487,23 @@ private:
             }
         }
 
+        for (const auto& controlInfo : model->getControls())
+        {
+            if (auto* fileInfo = dynamic_cast<FileComponentInfo*>(controlInfo.get()))
+            {
+                if (fileInfo->required && fileInfo->path.empty())
+                {
+                    AlertWindow::showMessageBoxAsync(
+                        AlertWindow::WarningIcon,
+                        "Error",
+                        "Required file input \"" + String(fileInfo->label)
+                            + "\" is empty. Please select a file before processing.");
+
+                    return;
+                }
+            }
+        }
+
         modelSelectionWidget.setDisabled();
         processCancelButton.setMode(cancelButtonInfo.displayLabel);
 

--- a/src/ModelTab.h
+++ b/src/ModelTab.h
@@ -553,7 +553,9 @@ private:
                         {
                             auto& outputMediaDisplays = outputTrackAreaWidget.getMediaDisplays();
 
-                            for (size_t i = 0; i < outputMediaDisplays.size(); ++i)
+                            for (size_t i = 0;
+                                 i < outputMediaDisplays.size() && i < outputFilesPtr->size();
+                                 ++i)
                             {
                                 outputMediaDisplays[i]->initializeDisplay(
                                     URL((*outputFilesPtr)[i]));

--- a/src/gui/ControlComponent.h
+++ b/src/gui/ControlComponent.h
@@ -26,6 +26,11 @@ public:
      */
     virtual int getMinimumRequiredWidth() const = 0;
 
+    /**
+     * Returns the preferred height for this control, or 0 to use the layout default.
+     */
+    virtual int getPreferredHeight() const { return 0; }
+
 protected:
     /** Default padding around the label */
     static constexpr int defaultPadding = 20;

--- a/src/gui/ControlComponent.h
+++ b/src/gui/ControlComponent.h
@@ -21,15 +21,15 @@ public:
     virtual ~ControlComponent() = default;
 
     /**
+     * Returns the preferred height for this control, or 0 to use the layout default.
+     */
+    virtual int getPreferredHeight() const { return 0; }
+
+    /**
      * Returns the minimum width required to display this control properly.
      * This includes the label width plus any necessary padding.
      */
     virtual int getMinimumRequiredWidth() const = 0;
-
-    /**
-     * Returns the preferred height for this control, or 0 to use the layout default.
-     */
-    virtual int getPreferredHeight() const { return 0; }
 
 protected:
     /** Default padding around the label */

--- a/src/gui/FileChooserWithLabel.h
+++ b/src/gui/FileChooserWithLabel.h
@@ -16,6 +16,9 @@ using namespace juce;
 
 class FileChooserWithLabel : public ControlComponent, public FileDragAndDropTarget
 {
+    static constexpr int bannerHeight = 14;
+    bool required = true;
+
 public:
     ~FileChooserWithLabel() { actionButton.setLookAndFeel(nullptr); }
 
@@ -33,14 +36,31 @@ public:
     {
         auto area = getLocalBounds();
         label.setBounds(area.removeFromTop(labelHeight));
+
+        if (! required)
+            area.removeFromTop(bannerHeight);
+
         int buttonSize = area.getHeight();
         actionButton.setBounds(area.removeFromRight(buttonSize));
     }
 
     void paint(Graphics& g) override
     {
-        auto body = getLocalBounds().withTrimmedTop(labelHeight).toFloat();
-        auto bodyInt = body.toNearestInt();
+        auto area = getLocalBounds();
+        area.removeFromTop(labelHeight);
+
+        if (! required)
+        {
+            auto bannerRect = area.removeFromTop(bannerHeight).toFloat();
+            g.setColour(Colour::fromRGB(90, 105, 105));
+            g.fillRect(bannerRect);
+            g.setColour(Colours::white);
+            g.setFont(Font(12.0f));
+            g.drawText("OPTIONAL", bannerRect, Justification::centred, false);
+        }
+
+        auto body = area.toFloat();
+        auto bodyInt = area;
         float r = 3.0f;
 
         auto bg = findColour(ComboBox::backgroundColourId);
@@ -84,6 +104,17 @@ public:
     }
 
     void setFileTypes(const std::vector<std::string>& types) { fileTypes = types; }
+
+    void setRequired(bool req)
+    {
+        required = req;
+        repaint();
+    }
+
+    int getPreferredHeight() const override
+    {
+        return minFilePickerHeight + (required ? 0 : bannerHeight);
+    }
 
     int getMinimumRequiredWidth() const override
     {
@@ -190,6 +221,7 @@ private:
     };
 
     static constexpr int minFilePickerWidth = 260;
+    static constexpr int minFilePickerHeight = 50;
     static constexpr int labelHeight = 20;
 
     NoBorderLookAndFeel noBorderLAF;

--- a/src/gui/FileChooserWithLabel.h
+++ b/src/gui/FileChooserWithLabel.h
@@ -1,24 +1,24 @@
+/**
+ * @file FileChooserWithLabel.h
+ * @brief Custom file chooser component with label.
+ * @author derekllanes, cwitkowitz
+ */
+
 #pragma once
 
-#include <juce_gui_basics/juce_gui_basics.h>
+#include <string>
+#include <vector>
 
 #include "ControlComponent.h"
-#include "../utils/Controls.h"
 
 using namespace juce;
 
-class FilePickerWithLabel : public ControlComponent, private Button::Listener
+class FileChooserWithLabel : public ControlComponent, private Button::Listener
 {
 public:
-    explicit FilePickerWithLabel(FilePickerComponentInfo* infoToUse)
-        : info(infoToUse),
-          browseButton("Browse...")
+    FileChooserWithLabel(const String& labelText = {})
     {
-        if (info != nullptr)
-        {
-            label.setText(info->label, dontSendNotification);
-        }
-
+        label.setText(labelText, dontSendNotification);
         label.setJustificationType(Justification::centred);
 
         pathBox.setReadOnly(true);
@@ -34,7 +34,7 @@ public:
         addAndMakeVisible(browseButton);
     }
 
-    ~FilePickerWithLabel() override
+    ~FileChooserWithLabel() override
     {
         browseButton.removeListener(this);
     }
@@ -43,50 +43,61 @@ public:
     {
         auto area = getLocalBounds();
 
-        auto labelArea = area.removeFromTop(20);
-        label.setBounds(labelArea);
+        label.setBounds(area.removeFromTop(labelHeight));
 
-        area.removeFromTop(4);
+        area.removeFromTop(labelGap);
 
-        auto buttonArea = area.removeFromLeft(90);
-        browseButton.setBounds(buttonArea);
+        browseButton.setBounds(area.removeFromLeft(browseButtonWidth));
 
-        area.removeFromLeft(6);
+        area.removeFromLeft(browseButtonGap);
         pathBox.setBounds(area);
+    }
+
+    void setPath(const String& path)
+    {
+        pathBox.setText(path, dontSendNotification);
+    }
+
+    void setFileTypes(const std::vector<std::string>& types)
+    {
+        fileTypes = types;
     }
 
     int getMinimumRequiredWidth() const override
     {
         const int labelWidth = getLabelWidth(label);
-        return jmax(260, labelWidth + defaultPadding);
+        return jmax(minFilePickerWidth, labelWidth + defaultPadding);
     }
+
+    TextEditor& getPathBox() { return pathBox; }
+
+    /** Called with full path after successful file choice. */
+    std::function<void(const String&)> onFileSelected;
 
 private:
     void buttonClicked(Button* button) override
     {
-        if (button != &browseButton || info == nullptr)
-        {
+        if (button != &browseButton)
             return;
-        }
-
-        String pattern = buildWildcardPattern();
 
         fileChooser = std::make_unique<FileChooser>(
             "Select file",
             File(),
-            pattern
+            buildWildcardPattern()
         );
 
         fileChooser->launchAsync(
             FileBrowserComponent::openMode | FileBrowserComponent::canSelectFiles,
             [this](const FileChooser& chooser)
             {
-                File selectedFile = chooser.getResult();
+                const File selectedFile = chooser.getResult();
 
                 if (selectedFile.existsAsFile())
                 {
-                    info->path = selectedFile.getFullPathName().toStdString();
                     pathBox.setText(selectedFile.getFullPathName(), dontSendNotification);
+
+                    if (onFileSelected)
+                        onFileSelected(selectedFile.getFullPathName());
                 }
             }
         );
@@ -94,21 +105,17 @@ private:
 
     String buildWildcardPattern() const
     {
-        if (info == nullptr || info->fileTypes.empty())
-        {
+        if (fileTypes.empty())
             return "*";
-        }
 
         StringArray patterns;
 
-        for (const auto& ext : info->fileTypes)
+        for (const auto& ext : fileTypes)
         {
             String extension(ext);
 
             if (! extension.startsWithChar('.'))
-            {
                 extension = "." + extension;
-            }
 
             patterns.add("*" + extension);
         }
@@ -116,11 +123,17 @@ private:
         return patterns.joinIntoString(";");
     }
 
-    FilePickerComponentInfo* info = nullptr;
+    static constexpr int minFilePickerWidth = 260;
+    static constexpr int labelHeight = 20;
+    static constexpr int labelGap = 4;
+    static constexpr int browseButtonWidth = 90;
+    static constexpr int browseButtonGap = 6;
+
+    std::vector<std::string> fileTypes;
 
     Label label;
     TextEditor pathBox;
-    TextButton browseButton;
+    TextButton browseButton { "Browse..." };
 
     std::unique_ptr<FileChooser> fileChooser;
 };

--- a/src/gui/FileChooserWithLabel.h
+++ b/src/gui/FileChooserWithLabel.h
@@ -10,58 +10,80 @@
 #include <vector>
 
 #include "ControlComponent.h"
+#include "MultiButton.h"
 
 using namespace juce;
 
-class FileChooserWithLabel : public ControlComponent, private Button::Listener
+class FileChooserWithLabel : public ControlComponent, public FileDragAndDropTarget
 {
 public:
+    ~FileChooserWithLabel() { actionButton.setLookAndFeel(nullptr); }
+
     FileChooserWithLabel(const String& labelText = {})
     {
         label.setText(labelText, dontSendNotification);
         label.setJustificationType(Justification::centred);
-
-        pathBox.setReadOnly(true);
-        pathBox.setText("No file selected", dontSendNotification);
-        pathBox.setMultiLine(false);
-        pathBox.setScrollbarsShown(false);
-        pathBox.setCaretVisible(false);
-
-        browseButton.addListener(this);
-
         addAndMakeVisible(label);
-        addAndMakeVisible(pathBox);
-        addAndMakeVisible(browseButton);
-    }
 
-    ~FileChooserWithLabel() override
-    {
-        browseButton.removeListener(this);
+        initializeButton();
+        addAndMakeVisible(actionButton);
     }
 
     void resized() override
     {
         auto area = getLocalBounds();
-
         label.setBounds(area.removeFromTop(labelHeight));
+        int buttonSize = area.getHeight();
+        actionButton.setBounds(area.removeFromRight(buttonSize));
+    }
 
-        area.removeFromTop(labelGap);
+    void paint(Graphics& g) override
+    {
+        auto body = getLocalBounds().withTrimmedTop(labelHeight).toFloat();
+        auto bodyInt = body.toNearestInt();
+        float r = 3.0f;
 
-        browseButton.setBounds(area.removeFromLeft(browseButtonWidth));
+        auto bg = findColour(ComboBox::backgroundColourId);
+        auto outline = findColour(ComboBox::outlineColourId);
+        auto textCol = findColour(ComboBox::textColourId);
 
-        area.removeFromLeft(browseButtonGap);
-        pathBox.setBounds(area);
+        g.setColour(bg);
+        g.fillRoundedRectangle(body.reduced(0.5f), r);
+        g.setColour(outline);
+        g.drawRoundedRectangle(body.reduced(0.5f), r, 1.0f);
+
+        auto textArea = bodyInt.withTrimmedRight(bodyInt.getHeight()).withTrimmedLeft(4);
+
+        g.setFont(Font(13.0f));
+        g.setColour(currentPath.isEmpty() ? textCol.withAlpha(0.4f) : textCol.withAlpha(0.85f));
+        g.drawText(currentPath.isEmpty() ? getPlaceholderText() : File(currentPath).getFileName(),
+                   textArea,
+                   Justification::centredLeft,
+                   true);
+    }
+
+    bool isInterestedInFileDrag(const StringArray&) override { return currentPath.isEmpty(); }
+
+    void filesDropped(const StringArray& files, int, int) override
+    {
+        if (! files.isEmpty())
+        {
+            File f(files[0]);
+
+            if (f.existsAsFile())
+                setAndNotify(f.getFullPathName());
+        }
     }
 
     void setPath(const String& path)
     {
-        pathBox.setText(path, dontSendNotification);
+        currentPath = path;
+        actionButton.setMode(currentPath.isEmpty() ? chooseFileModeInfo.displayLabel
+                                                   : removeFileModeInfo.displayLabel);
+        repaint();
     }
 
-    void setFileTypes(const std::vector<std::string>& types)
-    {
-        fileTypes = types;
-    }
+    void setFileTypes(const std::vector<std::string>& types) { fileTypes = types; }
 
     int getMinimumRequiredWidth() const override
     {
@@ -69,38 +91,77 @@ public:
         return jmax(minFilePickerWidth, labelWidth + defaultPadding);
     }
 
-    TextEditor& getPathBox() { return pathBox; }
-
-    /** Called with full path after successful file choice. */
     std::function<void(const String&)> onFileSelected;
 
 private:
-    void buttonClicked(Button* button) override
+    void initializeButton()
     {
-        if (button != &browseButton)
-            return;
+        chooseFileModeInfo = MultiButton::Mode { "ChooseFile",
+                                                 "Click to choose a file.",
+                                                 [this] { launchFileChooser(); },
+                                                 MultiButton::DrawingMode::IconOnly,
+                                                 Colours::lightblue,
+                                                 fontawesome::Folder };
 
-        fileChooser = std::make_unique<FileChooser>(
-            "Select file",
-            File(),
-            buildWildcardPattern()
-        );
+        removeFileModeInfo = MultiButton::Mode { "RemoveFile",
+                                                 "Click to remove the selected file.",
+                                                 [this] { clearFile(); },
+                                                 MultiButton::DrawingMode::IconOnly,
+                                                 Colours::orangered,
+                                                 fontawesome::Remove };
 
-        fileChooser->launchAsync(
-            FileBrowserComponent::openMode | FileBrowserComponent::canSelectFiles,
-            [this](const FileChooser& chooser)
-            {
-                const File selectedFile = chooser.getResult();
+        actionButton.addMode(chooseFileModeInfo);
+        actionButton.addMode(removeFileModeInfo);
+        actionButton.setMode(chooseFileModeInfo.displayLabel);
 
-                if (selectedFile.existsAsFile())
-                {
-                    pathBox.setText(selectedFile.getFullPathName(), dontSendNotification);
+        actionButton.setLookAndFeel(&noBorderLAF);
+    }
 
-                    if (onFileSelected)
-                        onFileSelected(selectedFile.getFullPathName());
-                }
-            }
-        );
+    String getPlaceholderText() const
+    {
+        if (fileTypes.empty())
+            return "No file selected";
+
+        StringArray exts;
+
+        for (const auto& ext : fileTypes)
+        {
+            String e(ext);
+            exts.add(e.startsWithChar('.') ? e : "." + e);
+        }
+
+        return "No file selected (" + exts.joinIntoString(", ") + ")";
+    }
+
+    void clearFile()
+    {
+        setPath({});
+
+        if (onFileSelected)
+            onFileSelected({});
+    }
+
+    void setAndNotify(const String& path)
+    {
+        setPath(path);
+
+        if (onFileSelected)
+            onFileSelected(path);
+    }
+
+    void launchFileChooser()
+    {
+        fileChooser = std::make_unique<FileChooser>("Select file", File(), buildWildcardPattern());
+
+        fileChooser->launchAsync(FileBrowserComponent::openMode
+                                     | FileBrowserComponent::canSelectFiles,
+                                 [this](const FileChooser& chooser)
+                                 {
+                                     const File f = chooser.getResult();
+
+                                     if (f.existsAsFile())
+                                         setAndNotify(f.getFullPathName());
+                                 });
     }
 
     String buildWildcardPattern() const
@@ -112,28 +173,32 @@ private:
 
         for (const auto& ext : fileTypes)
         {
-            String extension(ext);
+            String e(ext);
 
-            if (! extension.startsWithChar('.'))
-                extension = "." + extension;
+            if (! e.startsWithChar('.'))
+                e = "." + e;
 
-            patterns.add("*" + extension);
+            patterns.add("*" + e);
         }
 
         return patterns.joinIntoString(";");
     }
 
+    struct NoBorderLookAndFeel : public LookAndFeel_V4
+    {
+        void drawButtonBackground(Graphics&, Button&, const Colour&, bool, bool) override {}
+    };
+
     static constexpr int minFilePickerWidth = 260;
     static constexpr int labelHeight = 20;
-    static constexpr int labelGap = 4;
-    static constexpr int browseButtonWidth = 90;
-    static constexpr int browseButtonGap = 6;
 
-    std::vector<std::string> fileTypes;
-
+    NoBorderLookAndFeel noBorderLAF;
     Label label;
-    TextEditor pathBox;
-    TextButton browseButton { "Browse..." };
+    MultiButton actionButton;
+    MultiButton::Mode chooseFileModeInfo;
+    MultiButton::Mode removeFileModeInfo;
 
+    String currentPath;
+    std::vector<std::string> fileTypes;
     std::unique_ptr<FileChooser> fileChooser;
 };

--- a/src/gui/FileChooserWithLabel.h
+++ b/src/gui/FileChooserWithLabel.h
@@ -16,9 +16,6 @@ using namespace juce;
 
 class FileChooserWithLabel : public ControlComponent, public FileDragAndDropTarget
 {
-    static constexpr int bannerHeight = 14;
-    bool required = true;
-
 public:
     ~FileChooserWithLabel() { actionButton.setLookAndFeel(nullptr); }
 
@@ -223,6 +220,7 @@ private:
     static constexpr int minFilePickerWidth = 260;
     static constexpr int minFilePickerHeight = 50;
     static constexpr int labelHeight = 20;
+    static constexpr int bannerHeight = 14;
 
     NoBorderLookAndFeel noBorderLAF;
     Label label;
@@ -231,6 +229,7 @@ private:
     MultiButton::Mode removeFileModeInfo;
 
     String currentPath;
+    bool required = true;
     std::vector<std::string> fileTypes;
     std::unique_ptr<FileChooser> fileChooser;
 };

--- a/src/gui/FilePickerWithLabel.h
+++ b/src/gui/FilePickerWithLabel.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "ControlComponent.h"
+#include "../utils/Controls.h"
+
+using namespace juce;
+
+class FilePickerWithLabel : public ControlComponent, private Button::Listener
+{
+public:
+    explicit FilePickerWithLabel(FilePickerComponentInfo* infoToUse)
+        : info(infoToUse),
+          browseButton("Browse...")
+    {
+        if (info != nullptr)
+        {
+            label.setText(info->label, dontSendNotification);
+        }
+
+        label.setJustificationType(Justification::centred);
+
+        pathBox.setReadOnly(true);
+        pathBox.setText("No file selected", dontSendNotification);
+        pathBox.setMultiLine(false);
+        pathBox.setScrollbarsShown(false);
+        pathBox.setCaretVisible(false);
+
+        browseButton.addListener(this);
+
+        addAndMakeVisible(label);
+        addAndMakeVisible(pathBox);
+        addAndMakeVisible(browseButton);
+    }
+
+    ~FilePickerWithLabel() override
+    {
+        browseButton.removeListener(this);
+    }
+
+    void resized() override
+    {
+        auto area = getLocalBounds();
+
+        auto labelArea = area.removeFromTop(20);
+        label.setBounds(labelArea);
+
+        area.removeFromTop(4);
+
+        auto buttonArea = area.removeFromLeft(90);
+        browseButton.setBounds(buttonArea);
+
+        area.removeFromLeft(6);
+        pathBox.setBounds(area);
+    }
+
+    int getMinimumRequiredWidth() const override
+    {
+        const int labelWidth = getLabelWidth(label);
+        return jmax(260, labelWidth + defaultPadding);
+    }
+
+private:
+    void buttonClicked(Button* button) override
+    {
+        if (button != &browseButton || info == nullptr)
+        {
+            return;
+        }
+
+        String pattern = buildWildcardPattern();
+
+        fileChooser = std::make_unique<FileChooser>(
+            "Select file",
+            File(),
+            pattern
+        );
+
+        fileChooser->launchAsync(
+            FileBrowserComponent::openMode | FileBrowserComponent::canSelectFiles,
+            [this](const FileChooser& chooser)
+            {
+                File selectedFile = chooser.getResult();
+
+                if (selectedFile.existsAsFile())
+                {
+                    info->path = selectedFile.getFullPathName().toStdString();
+                    pathBox.setText(selectedFile.getFullPathName(), dontSendNotification);
+                }
+            }
+        );
+    }
+
+    String buildWildcardPattern() const
+    {
+        if (info == nullptr || info->fileTypes.empty())
+        {
+            return "*";
+        }
+
+        StringArray patterns;
+
+        for (const auto& ext : info->fileTypes)
+        {
+            String extension(ext);
+
+            if (! extension.startsWithChar('.'))
+            {
+                extension = "." + extension;
+            }
+
+            patterns.add("*" + extension);
+        }
+
+        return patterns.joinIntoString(";");
+    }
+
+    FilePickerComponentInfo* info = nullptr;
+
+    Label label;
+    TextEditor pathBox;
+    TextButton browseButton;
+
+    std::unique_ptr<FileChooser> fileChooser;
+};

--- a/src/gui/TextBoxWithLabel.h
+++ b/src/gui/TextBoxWithLabel.h
@@ -16,6 +16,7 @@ public:
     TextBoxWithLabel(const String& labelText)
     {
         label.setText(labelText, dontSendNotification);
+        label.setJustificationType(Justification::centred);
 
         textBox.setMultiLine(true, true);
         textBox.setReadOnly(false);

--- a/src/media/FileDisplayComponent.cpp
+++ b/src/media/FileDisplayComponent.cpp
@@ -1,0 +1,55 @@
+#include "FileDisplayComponent.h"
+
+FileDisplayComponent::FileDisplayComponent()
+    : FileDisplayComponent("File Track")
+{
+}
+
+FileDisplayComponent::FileDisplayComponent(String name, bool req, bool fromDAW, DisplayMode mode)
+    : MediaDisplayComponent(name, req, fromDAW, mode)
+{
+}
+
+FileDisplayComponent::~FileDisplayComponent()
+{
+}
+
+StringArray FileDisplayComponent::getSupportedExtensions()
+{
+    return {
+        ".nam",
+        ".txt",
+        ".csv",
+        ".json",
+        ".pth",
+        ".pt",
+        ".onnx"
+    };
+}
+
+StringArray FileDisplayComponent::getInstanceExtensions()
+{
+    return FileDisplayComponent::getSupportedExtensions();
+}
+
+double FileDisplayComponent::getTotalLengthInSecs()
+{
+    return 0.0;
+}
+
+void FileDisplayComponent::loadMediaFile(const URL& filePath)
+{
+    setTrackName(filePath.getFileName());
+    postLoadActions(filePath);
+    repaint();
+}
+
+void FileDisplayComponent::resetMedia()
+{
+    repaint();
+}
+
+void FileDisplayComponent::postLoadActions(const URL& /*filePath*/)
+{
+    // No extra action needed for generic files.
+}

--- a/src/media/FileDisplayComponent.cpp
+++ b/src/media/FileDisplayComponent.cpp
@@ -1,51 +1,106 @@
 #include "FileDisplayComponent.h"
 
-FileDisplayComponent::FileDisplayComponent()
-    : FileDisplayComponent("File Track")
-{
-}
+FileDisplayComponent::FileDisplayComponent() : FileDisplayComponent("File Track") {}
 
 FileDisplayComponent::FileDisplayComponent(String name, bool req, bool fromDAW, DisplayMode mode)
     : MediaDisplayComponent(name, req, fromDAW, mode)
 {
+    downloadActiveMode = MultiButton::Mode { "Download",
+                                             "Click to save the output file.",
+                                             [this] { saveFileCallback(); },
+                                             MultiButton::DrawingMode::IconOnly,
+                                             Colours::lightblue,
+                                             fontawesome::Save };
+    downloadInactiveMode =
+        MultiButton::Mode { "Download-Inactive", "No output file available.",
+                            [this] {},           MultiButton::DrawingMode::IconOnly,
+                            Colours::lightgrey,  fontawesome::Save };
+    downloadButton.addMode(downloadActiveMode);
+    downloadButton.addMode(downloadInactiveMode);
+    downloadButton.setMode(downloadInactiveMode.displayLabel);
+    downloadButton.setLookAndFeel(&noBorderLAF);
+
+    addAndMakeVisible(downloadButton);
 }
 
-FileDisplayComponent::~FileDisplayComponent()
-{
-}
+FileDisplayComponent::~FileDisplayComponent() { downloadButton.setLookAndFeel(nullptr); }
 
 StringArray FileDisplayComponent::getSupportedExtensions()
 {
-    return {
-        ".nam",
-        ".txt",
-        ".csv",
-        ".json",
-        ".pth",
-        ".pt",
-        ".onnx"
-    };
+    return {}; // Empty = accept all extensions
 }
 
 StringArray FileDisplayComponent::getInstanceExtensions()
 {
-    return FileDisplayComponent::getSupportedExtensions();
+    return instanceFileTypes; // Empty = accept all; populated from model metadata when provided
 }
 
-double FileDisplayComponent::getTotalLengthInSecs()
+void FileDisplayComponent::setInstanceFileTypes(const std::vector<std::string>& types)
 {
-    return 0.0;
+    instanceFileTypes.clear();
+
+    for (const auto& t : types)
+    {
+        String ext(t);
+
+        if (! ext.startsWithChar('.'))
+            ext = "." + ext;
+
+        instanceFileTypes.add(ext);
+    }
 }
 
-void FileDisplayComponent::loadMediaFile(const URL& filePath)
+double FileDisplayComponent::getTotalLengthInSecs() { return 0.0; }
+
+void FileDisplayComponent::paint(Graphics& g)
 {
-    setTrackName(filePath.getFileName());
-    postLoadActions(filePath);
+    auto body = getLocalBounds().withTrimmedTop(labelHeight).toFloat();
+    auto bodyInt = body.toNearestInt();
+    float r = 3.0f;
+
+    auto bg = findColour(ComboBox::backgroundColourId);
+    auto outline = findColour(ComboBox::outlineColourId);
+    auto textCol = findColour(ComboBox::textColourId);
+
+    // Draw label area
+    g.setFont(Font(14.0f));
+    g.setColour(textCol);
+    g.drawText(
+        getTrackName(), getLocalBounds().removeFromTop(labelHeight), Justification::centred, true);
+
+    // Draw body background
+    g.setColour(bg);
+    g.fillRoundedRectangle(body.reduced(0.5f), r);
+    g.setColour(outline);
+    g.drawRoundedRectangle(body.reduced(0.5f), r, 1.0f);
+
+    // Draw filename text (leaves space for the square button on the right)
+    auto textArea = bodyInt.withTrimmedRight(bodyInt.getHeight()).withTrimmedLeft(4);
+
+    g.setFont(Font(13.0f));
+    g.setColour(isFileLoaded() ? textCol.withAlpha(0.85f) : textCol.withAlpha(0.4f));
+    g.drawText(isFileLoaded() ? getOriginalFilePath().getFileName() : "No output file",
+               textArea,
+               Justification::centredLeft,
+               true);
+}
+
+void FileDisplayComponent::resized()
+{
+    auto area = getLocalBounds().withTrimmedTop(labelHeight);
+    int buttonSize = area.getHeight();
+    downloadButton.setBounds(area.removeFromRight(buttonSize));
+}
+
+void FileDisplayComponent::loadMediaFile(const URL& /*filePath*/)
+{
+    downloadButton.setMode(downloadActiveMode.displayLabel);
     repaint();
 }
 
 void FileDisplayComponent::resetMedia()
 {
+    downloadButton.setMode(downloadInactiveMode.displayLabel);
     repaint();
 }
 

--- a/src/media/FileDisplayComponent.h
+++ b/src/media/FileDisplayComponent.h
@@ -16,10 +16,34 @@ public:
 
     StringArray getInstanceExtensions() override;
 
+    int getFixedHeight() const override { return fixedHeight; }
+
     double getTotalLengthInSecs() override;
+
+    void paint(Graphics& g) override;
+    void resized() override;
 
     void loadMediaFile(const URL& filePath) override;
     void resetMedia() override;
 
     void postLoadActions(const URL& filePath) override;
+
+    void setInstanceFileTypes(const std::vector<std::string>& types);
+
+private:
+    struct NoBorderLookAndFeel : public LookAndFeel_V4
+    {
+        void drawButtonBackground(Graphics&, Button&, const Colour&, bool, bool) override {}
+    };
+
+    NoBorderLookAndFeel noBorderLAF;
+
+    MultiButton downloadButton;
+    MultiButton::Mode downloadActiveMode;
+    MultiButton::Mode downloadInactiveMode;
+
+    StringArray instanceFileTypes;
+
+    static constexpr int fixedHeight = 50;
+    static constexpr int labelHeight = 20;
 };

--- a/src/media/FileDisplayComponent.h
+++ b/src/media/FileDisplayComponent.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "MediaDisplayComponent.h"
+
+class FileDisplayComponent : public MediaDisplayComponent
+{
+public:
+    FileDisplayComponent();
+    FileDisplayComponent(String name,
+                         bool req = true,
+                         bool fromDAW = false,
+                         DisplayMode mode = DisplayMode::Input);
+    ~FileDisplayComponent() override;
+
+    static StringArray getSupportedExtensions();
+
+    StringArray getInstanceExtensions() override;
+
+    double getTotalLengthInSecs() override;
+
+    void loadMediaFile(const URL& filePath) override;
+    void resetMedia() override;
+
+    void postLoadActions(const URL& filePath) override;
+};

--- a/src/media/MediaDisplayComponent.cpp
+++ b/src/media/MediaDisplayComponent.cpp
@@ -857,13 +857,14 @@ void MediaDisplayComponent::saveFileCallback()
                     File chosenFile = fc.getResult();
                     if (chosenFile != File {})
                     {
-                        if (chosenFile.getFileExtension().compare("") == 0)
+                        if (chosenFile.getFileExtension().isEmpty() && ! validExtensions.isEmpty())
                         {
-                            // Add default extension in none provided
+                            // Add default extension if none provided and a specific list exists
                             chosenFile = chosenFile.withFileExtension(validExtensions[0]);
                         }
 
-                        if (validExtensions.contains(chosenFile.getFileExtension()))
+                        if (validExtensions.isEmpty()
+                            || validExtensions.contains(chosenFile.getFileExtension()))
                         {
                             //URL tempFilePath = mediaDisplay->getTempFilePath();
 

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -89,6 +89,9 @@ public:
     String getTrackName() { return trackName; }
 
     bool isRequired() const { return required; }
+
+    // Returns a fixed height in pixels this display should occupy, or 0 to use flex sizing.
+    virtual int getFixedHeight() const { return 0; }
     bool isLinkedToDAW() const { return linkedToDAW; }
 
     bool isInputTrack() { return (displayMode == DisplayMode::Input) || isHybridTrack(); }

--- a/src/media/MediaDisplayComponent.h
+++ b/src/media/MediaDisplayComponent.h
@@ -82,6 +82,9 @@ public:
     virtual void resized() override;
     void repositionLabels();
 
+    // Returns a fixed height in pixels this display should occupy, or 0 to use flex sizing.
+    virtual int getFixedHeight() const { return 0; }
+
     void setTrackID(Uuid id) { trackID = id; }
     Uuid getTrackID() { return trackID; }
 
@@ -89,9 +92,6 @@ public:
     String getTrackName() { return trackName; }
 
     bool isRequired() const { return required; }
-
-    // Returns a fixed height in pixels this display should occupy, or 0 to use flex sizing.
-    virtual int getFixedHeight() const { return 0; }
     bool isLinkedToDAW() const { return linkedToDAW; }
 
     bool isInputTrack() { return (displayMode == DisplayMode::Input) || isHybridTrack(); }

--- a/src/utils/Controls.h
+++ b/src/utils/Controls.h
@@ -83,29 +83,39 @@ struct MidiTrackComponentInfo : public TrackComponentInfo
     using TrackComponentInfo::TrackComponentInfo;
 };
 
-struct FilePickerComponentInfo : public ModelComponentInfo
+struct FileComponentInfo : public ModelComponentInfo // TODO - Listener?
 {
-    bool required = true;
     std::string path { "" };
     std::vector<std::string> fileTypes;
 
-    FilePickerComponentInfo(DynamicObject* input) : ModelComponentInfo(input)
+    FileComponentInfo(DynamicObject* input) : ModelComponentInfo(input)
     {
-        if (input->hasProperty("required"))
+        if (input->hasProperty("path"))
         {
-            required = stringToBool(input->getProperty("required").toString());
+            path = input->getProperty("path").toString().toStdString();
         }
 
         if (input->hasProperty("file_types"))
         {
             Array<var>* types = input->getProperty("file_types").getArray();
 
-            if (types != nullptr)
+            if (types == nullptr)
             {
-                for (int i = 0; i < types->size(); ++i)
+                // TODO - handle error case: couldn't load types
+            }
+
+            int numTypes = types->size();
+
+            if (numTypes > 0)
+            {
+                for (int j = 0; j < numTypes; j++)
                 {
-                    fileTypes.push_back(types->getReference(i).toString().toStdString());
+                    fileTypes.push_back(types->getReference(j).toString().toStdString());
                 }
+            }
+            else
+            {
+                // TODO - handle error case: no types
             }
         }
     }

--- a/src/utils/Controls.h
+++ b/src/utils/Controls.h
@@ -83,6 +83,12 @@ struct MidiTrackComponentInfo : public TrackComponentInfo
     using TrackComponentInfo::TrackComponentInfo;
 };
 
+// New struct for generic file type
+struct FileTrackComponentInfo : public TrackComponentInfo
+{
+    using TrackComponentInfo::TrackComponentInfo;
+};
+
 struct TextBoxComponentInfo : public ModelComponentInfo, public TextEditor::Listener
 {
     std::string value { "" };

--- a/src/utils/Controls.h
+++ b/src/utils/Controls.h
@@ -83,10 +83,32 @@ struct MidiTrackComponentInfo : public TrackComponentInfo
     using TrackComponentInfo::TrackComponentInfo;
 };
 
-// New struct for generic file type
-struct FileTrackComponentInfo : public TrackComponentInfo
+struct FilePickerComponentInfo : public ModelComponentInfo
 {
-    using TrackComponentInfo::TrackComponentInfo;
+    bool required = true;
+    std::string path { "" };
+    std::vector<std::string> fileTypes;
+
+    FilePickerComponentInfo(DynamicObject* input) : ModelComponentInfo(input)
+    {
+        if (input->hasProperty("required"))
+        {
+            required = stringToBool(input->getProperty("required").toString());
+        }
+
+        if (input->hasProperty("file_types"))
+        {
+            Array<var>* types = input->getProperty("file_types").getArray();
+
+            if (types != nullptr)
+            {
+                for (int i = 0; i < types->size(); ++i)
+                {
+                    fileTypes.push_back(types->getReference(i).toString().toStdString());
+                }
+            }
+        }
+    }
 };
 
 struct TextBoxComponentInfo : public ModelComponentInfo, public TextEditor::Listener

--- a/src/utils/Controls.h
+++ b/src/utils/Controls.h
@@ -85,11 +85,18 @@ struct MidiTrackComponentInfo : public TrackComponentInfo
 
 struct FileComponentInfo : public ModelComponentInfo // TODO - Listener?
 {
+    bool required = true;
+
     std::string path { "" };
     std::vector<std::string> fileTypes;
 
     FileComponentInfo(DynamicObject* input) : ModelComponentInfo(input)
     {
+        if (input->hasProperty("required"))
+        {
+            required = stringToBool(input->getProperty("required").toString());
+        }
+
         if (input->hasProperty("path"))
         {
             path = input->getProperty("path").toString().toStdString();

--- a/src/widgets/ControlAreaWidget.h
+++ b/src/widgets/ControlAreaWidget.h
@@ -310,9 +310,7 @@ private:
         fileChooserComponent->setFileTypes(info->fileTypes);
 
         fileChooserComponent->onFileSelected = [info](const String& path)
-        {
-            info->path = path.toStdString();
-        };
+        { info->path = path.toStdString(); };
 
         addHandler(fileChooserComponent.get(), info);
 

--- a/src/widgets/ControlAreaWidget.h
+++ b/src/widgets/ControlAreaWidget.h
@@ -307,6 +307,7 @@ private:
         if (! info->path.empty())
             fileChooserComponent->setPath(info->path);
 
+        fileChooserComponent->setRequired(info->required);
         fileChooserComponent->setFileTypes(info->fileTypes);
 
         fileChooserComponent->onFileSelected = [info](const String& path)
@@ -421,7 +422,11 @@ private:
 
             auto& activeRow = rows.back();
 
-            activeRow.push_back({ c.get(), itemWidth, spec.minHeight });
+            int itemHeight = c->getPreferredHeight();
+            if (itemHeight == 0)
+                itemHeight = spec.minHeight;
+
+            activeRow.push_back({ c.get(), itemWidth, itemHeight });
         }
     }
 

--- a/src/widgets/ControlAreaWidget.h
+++ b/src/widgets/ControlAreaWidget.h
@@ -16,6 +16,7 @@
 #include "../gui/SliderWithLabel.h"
 #include "../gui/TextBoxWithLabel.h"
 #include "../gui/ToggleWithLabel.h"
+#include "../gui/FilePickerWithLabel.h"
 
 #include "../utils/Controls.h"
 #include "../utils/Logging.h"
@@ -81,7 +82,7 @@ public:
     int getNumControls() const
     {
         return sliderComponents.size() + toggleComponents.size() + dropdownComponents.size()
-               + textComponents.size();
+            + textComponents.size() + filePickerComponents.size();
     }
 
     int getMinimumRequiredWidth() const
@@ -100,6 +101,7 @@ public:
         checkGroup(toggleComponents);
         checkGroup(dropdownComponents);
         checkGroup(textComponents);
+        checkGroup(filePickerComponents);
 
         return requiredWidth + 2 * (marginSize + minEdgeGap);
     }
@@ -156,6 +158,12 @@ public:
         }
         dropdownComponents.clear();
 
+        for (auto& c : filePickerComponents)
+        {
+            removeChildComponent(c.get());
+        }
+        filePickerComponents.clear();
+
         handlers.clear();
     }
 
@@ -181,6 +189,10 @@ public:
             else if (auto* dropdownInfo = dynamic_cast<ComboBoxComponentInfo*>(info.get()))
             {
                 addDropdown(dropdownInfo);
+            }
+            else if (auto* filePickerInfo = dynamic_cast<FilePickerComponentInfo*>(info.get()))
+            {
+                addFilePicker(filePickerInfo);
             }
             else
             {
@@ -287,6 +299,18 @@ private:
         dropdownComponents.push_back(std::move(dropdownComponent));
     }
 
+    void addFilePicker(FilePickerComponentInfo* info)
+    {
+        std::unique_ptr<FilePickerWithLabel> filePickerComponent =
+            std::make_unique<FilePickerWithLabel>(info);
+
+        addHandler(filePickerComponent.get(), info);
+
+        addAndMakeVisible(*filePickerComponent);
+
+        filePickerComponents.push_back(std::move(filePickerComponent));
+    }
+
     void addHandler(Component* comp, ModelComponentInfo* info)
     {
         std::unique_ptr<HoverHandler> handler = std::make_unique<HoverHandler>(*comp);
@@ -341,14 +365,16 @@ private:
         addGroupToRows(rows, toggleComponents, 1, width);
         addGroupToRows(rows, dropdownComponents, 2, width);
         addGroupToRows(rows, textComponents, 3, width);
+        addGroupToRows(rows, filePickerComponents, 4, width);
 
         return rows;
     }
 
+    template <typename ComponentList>
     void addGroupToRows(std::vector<std::vector<RowEntry>>& rows,
-                        const auto& components,
-                        int type,
-                        int availableWidth) const
+                const ComponentList& components,
+                int type,
+                int availableWidth) const
     {
         auto spec = getLayoutSpec(type);
 
@@ -403,6 +429,8 @@ private:
                 return { preferredDropdownWidth, minDropdownHeight };
             case 3:
                 return { preferredTextBoxWidth, minTextBoxHeight };
+            case 4:
+                return { preferredFilePickerWidth, minFilePickerHeight };
         }
 
         return { preferredDropdownWidth, minDropdownHeight };
@@ -426,11 +454,13 @@ private:
     static constexpr int minToggleHeight = 34;
     static constexpr int minDropdownHeight = 44;
     static constexpr int minTextBoxHeight = 84;
+    static constexpr int minFilePickerHeight = 64;
 
     static constexpr int preferredSliderWidth = 108;
     static constexpr int preferredToggleWidth = 112;
     static constexpr int preferredDropdownWidth = 140;
     static constexpr int preferredTextBoxWidth = 200;
+    static constexpr int preferredFilePickerWidth = 260;
 
     static constexpr int minInterItemGap = 6;
     static constexpr int minEdgeGap = 4;
@@ -441,6 +471,7 @@ private:
     std::vector<std::unique_ptr<ToggleWithLabel>> toggleComponents;
     std::vector<std::unique_ptr<SliderWithLabel>> sliderComponents;
     std::vector<std::unique_ptr<ComboBoxWithLabel>> dropdownComponents;
+    std::vector<std::unique_ptr<FilePickerWithLabel>> filePickerComponents;
 
     std::vector<std::unique_ptr<HoverHandler>> handlers;
 

--- a/src/widgets/ControlAreaWidget.h
+++ b/src/widgets/ControlAreaWidget.h
@@ -12,11 +12,11 @@
 #include "../widgets/StatusAreaWidget.h"
 
 #include "../gui/ComboBoxWithLabel.h"
+#include "../gui/FileChooserWithLabel.h"
 #include "../gui/HoverHandler.h"
 #include "../gui/SliderWithLabel.h"
 #include "../gui/TextBoxWithLabel.h"
 #include "../gui/ToggleWithLabel.h"
-#include "../gui/FilePickerWithLabel.h"
 
 #include "../utils/Controls.h"
 #include "../utils/Logging.h"
@@ -82,7 +82,7 @@ public:
     int getNumControls() const
     {
         return sliderComponents.size() + toggleComponents.size() + dropdownComponents.size()
-            + textComponents.size() + filePickerComponents.size();
+               + textComponents.size() + fileChooserComponents.size();
     }
 
     int getMinimumRequiredWidth() const
@@ -101,7 +101,7 @@ public:
         checkGroup(toggleComponents);
         checkGroup(dropdownComponents);
         checkGroup(textComponents);
-        checkGroup(filePickerComponents);
+        checkGroup(fileChooserComponents);
 
         return requiredWidth + 2 * (marginSize + minEdgeGap);
     }
@@ -158,11 +158,11 @@ public:
         }
         dropdownComponents.clear();
 
-        for (auto& c : filePickerComponents)
+        for (auto& c : fileChooserComponents)
         {
             removeChildComponent(c.get());
         }
-        filePickerComponents.clear();
+        fileChooserComponents.clear();
 
         handlers.clear();
     }
@@ -190,9 +190,9 @@ public:
             {
                 addDropdown(dropdownInfo);
             }
-            else if (auto* filePickerInfo = dynamic_cast<FilePickerComponentInfo*>(info.get()))
+            else if (auto* fileChooserInfo = dynamic_cast<FileComponentInfo*>(info.get()))
             {
-                addFilePicker(filePickerInfo);
+                addFileChooser(fileChooserInfo);
             }
             else
             {
@@ -299,16 +299,28 @@ private:
         dropdownComponents.push_back(std::move(dropdownComponent));
     }
 
-    void addFilePicker(FilePickerComponentInfo* info)
+    void addFileChooser(FileComponentInfo* info)
     {
-        std::unique_ptr<FilePickerWithLabel> filePickerComponent =
-            std::make_unique<FilePickerWithLabel>(info);
+        std::unique_ptr<FileChooserWithLabel> fileChooserComponent =
+            std::make_unique<FileChooserWithLabel>(info->label);
 
-        addHandler(filePickerComponent.get(), info);
+        auto& pathBox = fileChooserComponent->getPathBox();
 
-        addAndMakeVisible(*filePickerComponent);
+        if (! info->path.empty())
+            fileChooserComponent->setPath(info->path);
 
-        filePickerComponents.push_back(std::move(filePickerComponent));
+        fileChooserComponent->setFileTypes(info->fileTypes);
+
+        fileChooserComponent->onFileSelected = [info](const String& path)
+        {
+            info->path = path.toStdString();
+        };
+
+        addHandler(&pathBox, info);
+
+        addAndMakeVisible(*fileChooserComponent);
+
+        fileChooserComponents.push_back(std::move(fileChooserComponent));
     }
 
     void addHandler(Component* comp, ModelComponentInfo* info)
@@ -365,16 +377,16 @@ private:
         addGroupToRows(rows, toggleComponents, 1, width);
         addGroupToRows(rows, dropdownComponents, 2, width);
         addGroupToRows(rows, textComponents, 3, width);
-        addGroupToRows(rows, filePickerComponents, 4, width);
+        addGroupToRows(rows, fileChooserComponents, 4, width);
 
         return rows;
     }
 
     template <typename ComponentList>
     void addGroupToRows(std::vector<std::vector<RowEntry>>& rows,
-                const ComponentList& components,
-                int type,
-                int availableWidth) const
+                        const ComponentList& components,
+                        int type,
+                        int availableWidth) const
     {
         auto spec = getLayoutSpec(type);
 
@@ -471,7 +483,7 @@ private:
     std::vector<std::unique_ptr<ToggleWithLabel>> toggleComponents;
     std::vector<std::unique_ptr<SliderWithLabel>> sliderComponents;
     std::vector<std::unique_ptr<ComboBoxWithLabel>> dropdownComponents;
-    std::vector<std::unique_ptr<FilePickerWithLabel>> filePickerComponents;
+    std::vector<std::unique_ptr<FileChooserWithLabel>> fileChooserComponents;
 
     std::vector<std::unique_ptr<HoverHandler>> handlers;
 

--- a/src/widgets/ControlAreaWidget.h
+++ b/src/widgets/ControlAreaWidget.h
@@ -304,8 +304,6 @@ private:
         std::unique_ptr<FileChooserWithLabel> fileChooserComponent =
             std::make_unique<FileChooserWithLabel>(info->label);
 
-        auto& pathBox = fileChooserComponent->getPathBox();
-
         if (! info->path.empty())
             fileChooserComponent->setPath(info->path);
 
@@ -316,7 +314,7 @@ private:
             info->path = path.toStdString();
         };
 
-        addHandler(&pathBox, info);
+        addHandler(fileChooserComponent.get(), info);
 
         addAndMakeVisible(*fileChooserComponent);
 
@@ -466,7 +464,7 @@ private:
     static constexpr int minToggleHeight = 34;
     static constexpr int minDropdownHeight = 44;
     static constexpr int minTextBoxHeight = 84;
-    static constexpr int minFilePickerHeight = 64;
+    static constexpr int minFilePickerHeight = 50;
 
     static constexpr int preferredSliderWidth = 108;
     static constexpr int preferredToggleWidth = 112;

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -11,7 +11,6 @@
 #include "../media/AudioDisplayComponent.h"
 #include "../media/MediaDisplayComponent.h"
 #include "../media/MidiDisplayComponent.h"
-#include "../media/FileDisplayComponent.h"
 
 #include "../utils/Controls.h"
 #include "../utils/Interface.h"
@@ -215,11 +214,6 @@ public:
             m = std::make_unique<MidiDisplayComponent>(
                 label, midiTrackInfo->required, fromDAW, displayMode);
         }
-        else if (auto fileTrackInfo = dynamic_cast<FileTrackComponentInfo*>(trackInfo))
-        {
-            m = std::make_unique<FileDisplayComponent>(
-                label, fileTrackInfo->required, fromDAW, displayMode);
-        }
         else
         {
             DBG_AND_LOG(
@@ -311,15 +305,6 @@ public:
             midiTrackInfo->label = label.toStdString();
 
             trackInfo = std::move(midiTrackInfo);
-        }
-        else if (FileDisplayComponent::getSupportedExtensions().contains(ext))
-        {
-            auto fileTrackInfo = std::make_unique<FileTrackComponentInfo>();
-
-            fileTrackInfo->required = false;
-            fileTrackInfo->label = label.toStdString();
-
-            trackInfo = std::move(fileTrackInfo);
         }
         else
         {

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -11,6 +11,7 @@
 #include "../media/AudioDisplayComponent.h"
 #include "../media/MediaDisplayComponent.h"
 #include "../media/MidiDisplayComponent.h"
+#include "../media/FileDisplayComponent.h"
 
 #include "../utils/Controls.h"
 #include "../utils/Interface.h"
@@ -214,6 +215,11 @@ public:
             m = std::make_unique<MidiDisplayComponent>(
                 label, midiTrackInfo->required, fromDAW, displayMode);
         }
+        else if (auto fileTrackInfo = dynamic_cast<FileTrackComponentInfo*>(trackInfo))
+        {
+            m = std::make_unique<FileDisplayComponent>(
+                label, fileTrackInfo->required, fromDAW, displayMode);
+        }
         else
         {
             DBG_AND_LOG(
@@ -305,6 +311,15 @@ public:
             midiTrackInfo->label = label.toStdString();
 
             trackInfo = std::move(midiTrackInfo);
+        }
+        else if (FileDisplayComponent::getSupportedExtensions().contains(ext))
+        {
+            auto fileTrackInfo = std::make_unique<FileTrackComponentInfo>();
+
+            fileTrackInfo->required = false;
+            fileTrackInfo->label = label.toStdString();
+
+            trackInfo = std::move(fileTrackInfo);
         }
         else
         {

--- a/src/widgets/TrackAreaWidget.h
+++ b/src/widgets/TrackAreaWidget.h
@@ -9,6 +9,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../media/AudioDisplayComponent.h"
+#include "../media/FileDisplayComponent.h"
 #include "../media/MediaDisplayComponent.h"
 #include "../media/MidiDisplayComponent.h"
 
@@ -51,9 +52,15 @@ public:
             {
                 FlexItem i = FlexItem(*m);
 
+                int fixedH = m->getFixedHeight();
+
                 if (fixedTrackHeight)
                 {
                     i = i.withHeight(fixedTrackHeight);
+                }
+                else if (fixedH > 0)
+                {
+                    i = i.withHeight(fixedH).withFlex(0);
                 }
                 else
                 {
@@ -243,6 +250,25 @@ public:
         }
     }
 
+    void addFileOutputFromComponentInfo(FileComponentInfo* fileInfo)
+    {
+        std::string label = fileInfo->label.empty() ? "File Output" : fileInfo->label;
+
+        auto m = std::make_unique<FileDisplayComponent>(String(label), false, false, displayMode);
+
+        m->setTrackID(fileInfo->id);
+        m->setInstanceFileTypes(fileInfo->fileTypes);
+
+        if (! fileInfo->info.empty())
+            m->setMediaInstructions(fileInfo->info);
+
+        m->addChangeListener(this);
+        addAndMakeVisible(m.get());
+        mediaDisplays.push_back(std::move(m));
+
+        resized();
+    }
+
     void updateTracks(const ModelComponentInfoList& trackComponents)
     {
         resetState();
@@ -253,9 +279,13 @@ public:
             {
                 addTrackFromComponentInfo(trackInfo);
             }
+            else if (auto* fileInfo = dynamic_cast<FileComponentInfo*>(info.get()))
+            {
+                addFileOutputFromComponentInfo(fileInfo);
+            }
             else
             {
-                // Invalid input track
+                // Invalid track component
                 jassertfalse;
             }
         }


### PR DESCRIPTION
## Summary

This PR adds support for generic file inputs as GUI controls

The intended behavior is:
- `gr.File(...)` inputs for MIDI files (`.mid`, `.midi`) still behave as MIDI tracks.
- Other `gr.File(...)` inputs become a generic file picker control in the GUI.
- The file picker uses the model builder’s label and allowed file extensions from `app.py`.
- HARP does not hardcode a specific use case like NAM. The model builder controls what file types are allowed through `file_types`.

In the HARP UI, the new control appears as:
- a label from the model definition
- a `Browse...` button
- a read-only text field showing `No file selected` or the selected file path

What Changed

pyharp:
- Added a new HarpFilePicker component type.
- Updated generic gr.File(...) handling so non-MIDI file inputs are represented as file_picker.
- Preserved the model builder’s label, info, required, and file_types values.
- Updated the UI tester app with a generic file input for testing.

HARP:
- Added FilePickerComponentInfo to store: selected file path, required status, allowed file extensions
- Updated Model.h so file_picker inputs are parsed as GUI controls rather than input tracks.
- Added FilePickerWithLabel
- Updated ControlAreaWidget to display file picker controls alongside sliders, dropdowns, toggles, and text boxes.
- Removed the old generic file-track routing from TrackAreaWidget, since generic files should now be selected through the GUI control system.

TESTING
While testing with the updated "ui_tester" in pyharp is working. Note that extensive testing has not been done.
